### PR TITLE
disable coverage in build.sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -101,5 +101,4 @@ lazy val root = (project in file("."))
       case Cmd("USER", args @ _*) => true
       case cmd                    => false
     },
-    coverageEnabled := true
   )


### PR DESCRIPTION
Disable the coverage in the `build.sbt`. For some reason if this flag is set to true the coverage is added to the docker container and prevents the container from properly starting up:

```
2023-06-30 17:34:05 Exception in thread "main" java.lang.ExceptionInInitializerError
2023-06-30 17:34:05 at swiss.dasch.Main$.<clinit>(Main.scala:22)
2023-06-30 17:34:05 at swiss.dasch.Main.main(Main.scala)
2023-06-30 17:34:05 Caused by: java.io.FileNotFoundException: /Users/mpro/repos/dsp-ingest/target/scala-3.3.0/scoverage-data/scoverage.measurements.a0c18b7e-a94f-4b04-babb-91c7abceb6cc.1 (No such file or directory)
2023-06-30 17:34:05 at java.base/java.io.FileOutputStream.open0(Native Method)
2023-06-30 17:34:05 at java.base/java.io.FileOutputStream.open(FileOutputStream.java:293)
2023-06-30 17:34:05 at java.base/java.io.FileOutputStream.<init>(FileOutputStream.java:235)
2023-06-30 17:34:05 at java.base/java.io.FileWriter.<init>(FileWriter.java:113)
```