### PR TITLE
fix: Enable request streaming

### DIFF
--- a/src/main/scala/swiss/dasch/infrastructure/IngestApiServer.scala
+++ b/src/main/scala/swiss/dasch/infrastructure/IngestApiServer.scala
@@ -33,7 +33,7 @@ object IngestApiServer {
   val layer: URLayer[ServiceConfig, Server] = ZLayer
     .service[ServiceConfig]
     .flatMap { cfg =>
-      Server.defaultWith(_.binding(cfg.get.host, cfg.get.port))
+      Server.defaultWith(_.binding(cfg.get.host, cfg.get.port).enableRequestStreaming)
     }
     .orDie
 }


### PR DESCRIPTION
When uploading an import zip the `Server` rejected it with a 413 response: `Request Entity Too Large`

Enabling streaming the reqest prevents this error.