### PR TITLE
fix: Allow underscore in AssetIds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           java-version: ${{ matrix.java-version }}
           cache: sbt
       - name: Build and Test
-        run: sbt -v coverage test headerCheckAll fmtCheck coverageAggregate
+        run: sbt -v clean coverage test headerCheckAll fmtCheck coverageAggregate
       - name: Unit Test Report
         uses: dorny/test-reporter@v1
         if: success() || failure()

--- a/src/main/scala/swiss/dasch/domain/Asset.scala
+++ b/src/main/scala/swiss/dasch/domain/Asset.scala
@@ -10,7 +10,7 @@ import eu.timepit.refined.refineV
 import eu.timepit.refined.string.MatchesRegex
 import zio.nio.file.Path
 
-opaque type AssetId = String Refined MatchesRegex["^[a-zA-Z0-9-]{4,}$"]
+opaque type AssetId = String Refined MatchesRegex["^[a-zA-Z0-9-_]{4,}$"]
 object AssetId {
   def make(id: String): Either[String, AssetId] = refineV(id)
 

--- a/src/test/scala/swiss/dasch/domain/AssetIdSpec.scala
+++ b/src/test/scala/swiss/dasch/domain/AssetIdSpec.scala
@@ -9,7 +9,7 @@ import zio.test.*
 
 object AssetIdSpec extends ZIOSpecDefault {
 
-  private val validCharacters = Gen.oneOf(Gen.alphaNumericChar, Gen.const('-'))
+  private val validCharacters = Gen.oneOf(Gen.alphaNumericChar, Gen.const('-'), Gen.const('_'))
 
   val spec = suite("AssetIdSpec")(
     test("AssetId should be created from a valid string") {


### PR DESCRIPTION
While running the topleft correction maintenance action on test I discovered that some assets in the 0803 project have names like `incunabula_0000004791.jp2` containing an underscore.

Fix the `AssetId` model to allow for underscores in the `AssetId` model.