### PR TITLE
feat: Add bulk ingest for images

### DIFF
--- a/src/main/scala/swiss/dasch/Main.scala
+++ b/src/main/scala/swiss/dasch/Main.scala
@@ -27,6 +27,7 @@ object Main extends ZIOAppDefault {
       .provide(
         AssetInfoServiceLive.layer,
         AuthenticatorLive.layer,
+        BulkIngestServiceLive.layer,
         Configuration.layer,
         FileChecksumServiceLive.layer,
         FileSystemCheckLive.layer,

--- a/src/main/scala/swiss/dasch/api/IngestEndpoint.scala
+++ b/src/main/scala/swiss/dasch/api/IngestEndpoint.scala
@@ -1,0 +1,79 @@
+package swiss.dasch.api
+
+import zio.http.endpoint.Endpoint
+import swiss.dasch.api.ApiPathCodecSegments.projects
+import swiss.dasch.api.ApiPathCodecSegments.shortcodePathVar
+import zio.http.Status
+import zio.*
+import zio.nio.file.Files
+import swiss.dasch.api.ListProjectsEndpoint.ProjectResponse
+import swiss.dasch.domain.ProjectShortcode
+import zio.http.codec.HttpCodec
+import swiss.dasch.domain.StorageService
+import swiss.dasch.domain.FileFilters
+import zio.nio.file.Path
+import swiss.dasch.domain.AssetId
+
+object IngestEndpoint {
+
+  val endpoint = Endpoint
+    .post(projects / shortcodePathVar / "bulk-ingest")
+    .out[ProjectResponse]
+    .outErrors(
+      HttpCodec.error[ProjectNotFound](Status.NotFound),
+      HttpCodec.error[IllegalArguments](Status.BadRequest),
+      HttpCodec.error[InternalProblem](Status.InternalServerError),
+    )
+
+  val route = endpoint.implement(shortcode =>
+    ApiStringConverters.fromPathVarToProjectShortcode(shortcode).flatMap { code =>
+      BulkIngestService
+        .startBulkIngest(code)
+        .mapError(ApiProblem.internalError(_))
+        .as(ProjectResponse(code))
+    }
+  )
+
+}
+
+trait BulkIngestService {
+
+  def startBulkIngest(shortcode: ProjectShortcode): Task[Unit]
+}
+
+object BulkIngestService {
+  def startBulkIngest(shortcode: ProjectShortcode): ZIO[BulkIngestService, Throwable, Unit] =
+    ZIO.serviceWithZIO[BulkIngestService](_.startBulkIngest(shortcode))
+}
+
+final case class BulkIngestServiceLive(storage: StorageService) extends BulkIngestService {
+
+  override def startBulkIngest(shortcode: ProjectShortcode): Task[Unit] =
+    for {
+      importDir  <- storage.getTempDirectory().map(_ / "import" / shortcode.value)
+      imageFiles <- StorageService.findInPath(importDir, FileFilters.isImage).runCollect
+      projectDir <- createProjectDirectory(shortcode)
+      _          <- ZIO.foreachDiscard(imageFiles)(ingestSingleImage(_, projectDir))
+    } yield ()
+
+  private def createProjectDirectory(code: ProjectShortcode): Task[Path] =
+    for {
+      projectDir <- storage.getProjectDirectory(code)
+      _          <- ZIO.whenZIO(Files.isDirectory(projectDir).negate)(Files.createDirectories(projectDir))
+    } yield projectDir
+
+  private def ingestSingleImage(file: Path, projectDir: Path): Task[Unit] =
+    for {
+      _                <- ZIO.unit
+      assetId: AssetId <- ZIO.succeed(???)
+      _                <- copyOriginal
+      _                <- createJpeg2000
+      _                <- createInfoFile
+      _                <- removeTempFile
+    } yield ()
+
+}
+
+object BulkIngestServiceLive {
+  val layer = ZLayer.fromFunction(BulkIngestServiceLive.apply _)
+}

--- a/src/main/scala/swiss/dasch/api/IngestEndpoint.scala
+++ b/src/main/scala/swiss/dasch/api/IngestEndpoint.scala
@@ -1,3 +1,8 @@
+/*
+ * Copyright © 2021 - 2023 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package swiss.dasch.api
 
 import org.apache.commons.io.FilenameUtils

--- a/src/main/scala/swiss/dasch/domain/AssetId.scala
+++ b/src/main/scala/swiss/dasch/domain/AssetId.scala
@@ -34,3 +34,7 @@ object AssetId {
 }
 
 final case class Asset(id: AssetId, belongsToProject: ProjectShortcode)
+
+object Asset {
+  def makeNew(project: ProjectShortcode): UIO[Asset] = AssetId.makeNew.map(id => Asset(id, project))
+}

--- a/src/main/scala/swiss/dasch/domain/AssetId.scala
+++ b/src/main/scala/swiss/dasch/domain/AssetId.scala
@@ -31,9 +31,6 @@ object AssetId {
       case false => None
     }
   }
-
-//  def makeNew: UIO[AssetId] = ZIO.succeed(Base62.encode(UUID.randomUUID())).map(AssetId.make)
-
 }
 
 final case class Asset(id: AssetId, belongsToProject: ProjectShortcode)

--- a/src/main/scala/swiss/dasch/domain/AssetId.scala
+++ b/src/main/scala/swiss/dasch/domain/AssetId.scala
@@ -8,11 +8,21 @@ package swiss.dasch.domain
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.refineV
 import eu.timepit.refined.string.MatchesRegex
+import swiss.dasch.infrastructure.Base62
+import zio.{ Random, UIO }
 import zio.nio.file.Path
 
 opaque type AssetId = String Refined MatchesRegex["^[a-zA-Z0-9-_]{4,}$"]
+
 object AssetId {
   def make(id: String): Either[String, AssetId] = refineV(id)
+
+  def makeNew: UIO[AssetId] = Random
+    .nextUUID
+    .map(uuid =>
+      // the unsafeApply is safe here because the [[Base62EncodedUuid]] is valid subset of AssetId
+      Refined.unsafeApply(Base62.encode(uuid).value)
+    )
 
   def makeFromPath(file: Path): Option[AssetId] = {
     val filename = file.filename.toString
@@ -21,6 +31,9 @@ object AssetId {
       case false => None
     }
   }
+
+//  def makeNew: UIO[AssetId] = ZIO.succeed(Base62.encode(UUID.randomUUID())).map(AssetId.make)
+
 }
 
 final case class Asset(id: AssetId, belongsToProject: ProjectShortcode)

--- a/src/main/scala/swiss/dasch/domain/SipiClient.scala
+++ b/src/main/scala/swiss/dasch/domain/SipiClient.scala
@@ -85,7 +85,7 @@ object SipiClient {
   def applyTopLeftCorrection(fileIn: Path, fileOut: Path): RIO[SipiClient, SipiOutput] =
     ZIO.serviceWithZIO[SipiClient](_.applyTopLeftCorrection(fileIn, fileOut))
 
-  def queryImageFile(file: Path): RIO[SipiClient, SipiOutput] =
+  def queryImageFile(file: Path): ZIO[SipiClient, IOException, SipiOutput] =
     ZIO.serviceWithZIO[SipiClient](_.queryImageFile(file))
 
   def transcodeImageFile(

--- a/src/main/scala/swiss/dasch/infrastructure/Base62.scala
+++ b/src/main/scala/swiss/dasch/infrastructure/Base62.scala
@@ -1,3 +1,8 @@
+/*
+ * Copyright © 2021 - 2023 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package swiss.dasch.infrastructure
 
 import eu.timepit.refined.api.Refined

--- a/src/main/scala/swiss/dasch/infrastructure/Base62.scala
+++ b/src/main/scala/swiss/dasch/infrastructure/Base62.scala
@@ -1,0 +1,90 @@
+package swiss.dasch.infrastructure
+
+import eu.timepit.refined.api.Refined
+import eu.timepit.refined.string.MatchesRegex
+
+import java.util.UUID
+
+/** [[Base62EncodedUuid]] is a valid subset of [[AssetId]]s that is used for creating new ids. A 23 character long
+  * String that contains only the characters a-z, A-Z, 0-9 and a single hyphen. The hyphen separates the most and least
+  * significant bits of the UUID. The first 11 characters are the most significant bits of the UUID. The last 11
+  * characters are the least significant bits of the UUID. This encoding is URL safe and can be used as a path parameter
+  * in a URL.
+  */
+type Base62EncodedUuid = String Refined MatchesRegex["^[a-zA-Z0-9]{11}-[a-zA-Z0-9]{11}$"]
+
+object Base62 {
+
+  private val Base62Alphabet = ((0 to 9) ++ ('A' to 'Z') ++ ('a' to 'z')).mkString
+
+  def encode(uuid: UUID): Base62EncodedUuid = {
+    val uuidBytes      = uuidToBytes(uuid)
+    val number         = bytesToBigInt(uuidBytes)
+    val encoded        = base62Encode(number)
+    val padded: String = addPadding(encoded)
+    Refined.unsafeApply(padded.substring(0, 11) + "-" + padded.substring(11, 22))
+  }
+
+  private def uuidToBytes(uuid: UUID): Array[Byte] = {
+    val buffer = new Array[Byte](16)
+    val msb    = uuid.getMostSignificantBits
+    val lsb    = uuid.getLeastSignificantBits
+
+    for (i <- 0 until 8) {
+      buffer(i) = ((msb >> ((7 - i) * 8)) & 0xff).toByte
+      buffer(8 + i) = ((lsb >> ((7 - i) * 8)) & 0xff).toByte
+    }
+    buffer
+  }
+
+  private def bytesToBigInt(bytes: Array[Byte]): BigInt = BigInt(1, bytes)
+
+  private def base62Encode(number: BigInt): String = {
+    var quotient = number
+    val base     = BigInt(Base62Alphabet.length)
+
+    var result = ""
+    while (quotient > 0) {
+      val remainder = (quotient % base).intValue()
+      result = s"${Base62Alphabet.charAt(remainder)}$result"
+      quotient /= base
+    }
+
+    result
+  }
+
+  private def addPadding(encoded: String) = {
+    val paddingLength = 22 - encoded.length // 22 is the length of our base62-encoded UUID
+    "0" * paddingLength + encoded
+  }
+
+  def decode(base62String: Base62EncodedUuid): UUID = {
+    val number    = base62Decode(base62String.toString.replace("-", ""))
+    val uuidBytes = bigIntToBytes(number)
+    bytesToUUID(uuidBytes)
+  }
+
+  private def base62Decode(base62String: String): BigInt = {
+    val base           = BigInt(Base62Alphabet.length)
+    val reversedString = base62String.reverse
+
+    reversedString.zipWithIndex.foldLeft(BigInt(0)) {
+      case (acc, (char, index)) =>
+        val value = Base62Alphabet.indexOf(char)
+        acc + (BigInt(value) * base.pow(index))
+    }
+  }
+
+  private def bigIntToBytes(number: BigInt): Array[Byte] = {
+    val bytes = number.toByteArray
+    if (bytes.length == 16) bytes
+    else if (bytes.length < 16) Array.fill[Byte](16 - bytes.length)(0.toByte) ++ bytes
+    else bytes.slice(bytes.length - 16, bytes.length)
+  }
+
+  private def bytesToUUID(bytes: Array[Byte]): UUID = {
+    val msb = BigInt(1, bytes.slice(0, 8))
+    val lsb = BigInt(1, bytes.slice(8, 16))
+    new UUID(msb.longValue(), lsb.longValue())
+  }
+}

--- a/src/main/scala/swiss/dasch/infrastructure/IngestApiServer.scala
+++ b/src/main/scala/swiss/dasch/infrastructure/IngestApiServer.scala
@@ -5,7 +5,8 @@
 
 package swiss.dasch.infrastructure
 
-import swiss.dasch.api.*
+import swiss.dasch.api.{ IngestEndpoint, * }
+import swiss.dasch.api.IngestEndpoint.*
 import swiss.dasch.api.monitoring.{ HealthEndpoint, InfoEndpoint, MetricsEndpoint }
 import swiss.dasch.config.Configuration.ServiceConfig
 import swiss.dasch.version.BuildInfo
@@ -18,6 +19,7 @@ object IngestApiServer {
   private val serviceApps    =
     (ExportEndpoint.app ++
       ImportEndpoint.app ++
+      IngestEndpoint.app ++
       ListProjectsEndpoint.app ++
       ReportEndpoint.app ++
       MaintenanceEndpointRoutes.app) @@ Authenticator.middleware

--- a/src/test/scala/swiss/dasch/domain/AssetIdSpec.scala
+++ b/src/test/scala/swiss/dasch/domain/AssetIdSpec.scala
@@ -5,6 +5,8 @@
 
 package swiss.dasch.domain
 
+import swiss.dasch.domain
+import zio.Random
 import zio.test.*
 
 object AssetIdSpec extends ZIOSpecDefault {
@@ -25,6 +27,13 @@ object AssetIdSpec extends ZIOSpecDefault {
     test("AssetId should not be created from a String shorter than four characters") {
       val validButTooShort = Gen.stringBounded(0, 3)(validCharacters)
       check(validButTooShort)(s => assertTrue(AssetId.make(s).isLeft))
+    },
+    test("AssetId.makeNew should create a UUID in Base 62 encoding") {
+      val uuid = "4sAf4AmPeeg-ZjDn3Tot1Zt"
+      for {
+        _  <- Random.setSeed(1977)
+        id <- AssetId.makeNew
+      } yield assertTrue(id.toString == uuid)
     },
   )
 }

--- a/src/test/scala/swiss/dasch/infrastructure/Base62Spec.scala
+++ b/src/test/scala/swiss/dasch/infrastructure/Base62Spec.scala
@@ -1,3 +1,8 @@
+/*
+ * Copyright © 2021 - 2023 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package swiss.dasch.infrastructure
 
 import zio.ZIO

--- a/src/test/scala/swiss/dasch/infrastructure/Base62Spec.scala
+++ b/src/test/scala/swiss/dasch/infrastructure/Base62Spec.scala
@@ -1,0 +1,21 @@
+package swiss.dasch.infrastructure
+
+import zio.ZIO
+import zio.test.{ Gen, ZIOSpecDefault, assertTrue, check }
+
+import java.util.UUID
+
+object Base62Spec extends ZIOSpecDefault {
+
+  private val genUuid = Gen.fromZIO(ZIO.succeed(UUID.randomUUID()))
+
+  val spec = suite("Base62")(
+    test("should encode and decode a UUID") {
+      check(genUuid) { uuid =>
+        val encoded: Base62EncodedUuid = Base62.encode(uuid)
+        val decoded: UUID              = Base62.decode(encoded)
+        assertTrue(uuid == decoded)
+      }
+    }
+  )
+}


### PR DESCRIPTION
Adds a bulk ingest endpoint:
```
POST /projects/<shortcode>/bulk-ingest HTTP/1.1
Authorization: Bearer <token>
Host: localhost:3340
```

Only ingests images by traversing the `tmp/import/<shortcode>` folder and for each image it:
* creates `.orig`
* creates derivative `.jpx`, should Sipi fail to transcode this image logs an error and skips the following steps
* creates `.info` with checksums and original filename
* creates a `mapping.csv` which contains `originalFilename, internalFilename` mapping
* removes the image from the temp folder.

