### PR TITLE
fix: Skip images which Sipi fails to transcode while creating originals

### DIFF
--- a/src/main/scala/swiss/dasch/domain/MaintenanceActions.scala
+++ b/src/main/scala/swiss/dasch/domain/MaintenanceActions.scala
@@ -85,7 +85,7 @@ object MaintenanceActions {
   }
 
   private def createOriginalAndUpdateInfoFile =
-    (c: CreateOriginalFor) => createOriginal(c) *> updateAssetInfo(c) as 1
+    (c: CreateOriginalFor) => createOriginal(c) *> updateAssetInfo(c)
 
   private def createOriginal(c: CreateOriginalFor) =
     ZIO.logInfo(s"Creating ${c.originalPath}/${c.targetFormat} for ${c.jpxPath}") *>
@@ -93,14 +93,16 @@ object MaintenanceActions {
         .transcodeImageFile(fileIn = c.jpxPath, fileOut = c.originalPath, outputFormat = c.targetFormat)
         .tap(sipiOut => ZIO.logDebug(s"Sipi response for $c: $sipiOut"))
 
-  private def updateAssetInfo(c: CreateOriginalFor) = {
+  private def updateAssetInfo(c: CreateOriginalFor): Task[Int] = {
     val infoFilePath = c.jpxPath.parent.orNull / s"${c.assetId}.info"
-    for {
-      _    <- ZIO.logInfo(s"Updating ${c.assetId} info file $infoFilePath")
-      info <- createNewAssetInfoFileContent(c)
-      _    <- Files.deleteIfExists(infoFilePath) *> Files.createFile(infoFilePath)
-      _    <- Files.writeBytes(infoFilePath, Chunk.fromArray(info.toJsonPretty.getBytes))
-    } yield ()
+    ZIO
+      .whenZIO(Files.exists(c.originalPath))(for {
+        _    <- ZIO.logInfo(s"Updating ${c.assetId} info file $infoFilePath")
+        info <- createNewAssetInfoFileContent(c)
+        _    <- Files.deleteIfExists(infoFilePath) *> Files.createFile(infoFilePath)
+        _    <- Files.writeBytes(infoFilePath, Chunk.fromArray(info.toJsonPretty.getBytes))
+      } yield 1)
+      .someOrElseZIO(ZIO.logWarning(s"Sipi did not create an original for ${c.jpxPath}") *> ZIO.succeed(0))
   }
 
   private def createNewAssetInfoFileContent(c: CreateOriginalFor): IO[Throwable, AssetInfoFileContent] =

--- a/src/main/scala/swiss/dasch/domain/MaintenanceActions.scala
+++ b/src/main/scala/swiss/dasch/domain/MaintenanceActions.scala
@@ -102,9 +102,7 @@ object MaintenanceActions {
         _    <- Files.deleteIfExists(infoFilePath) *> Files.createFile(infoFilePath)
         _    <- Files.writeBytes(infoFilePath, Chunk.fromArray(info.toJsonPretty.getBytes))
       } yield 1)
-      .someOrElseZIO(
-        ZIO.logWarning(s"Sipi did not create an original for $c") *> ZIO.succeed(0)
-      )
+      .someOrElseZIO(ZIO.logWarning(s"Sipi did not create an original for $c") *> ZIO.succeed(0))
   }
 
   private def createNewAssetInfoFileContent(c: CreateOriginalFor): IO[Throwable, AssetInfoFileContent] =

--- a/src/main/scala/swiss/dasch/domain/MaintenanceActions.scala
+++ b/src/main/scala/swiss/dasch/domain/MaintenanceActions.scala
@@ -102,7 +102,9 @@ object MaintenanceActions {
         _    <- Files.deleteIfExists(infoFilePath) *> Files.createFile(infoFilePath)
         _    <- Files.writeBytes(infoFilePath, Chunk.fromArray(info.toJsonPretty.getBytes))
       } yield 1)
-      .someOrElseZIO(ZIO.logWarning(s"Sipi did not create an original for ${c.jpxPath}") *> ZIO.succeed(0))
+      .someOrElseZIO(
+        ZIO.logWarning(s"Sipi did not create an original for $c") *> ZIO.succeed(0)
+      )
   }
 
   private def createNewAssetInfoFileContent(c: CreateOriginalFor): IO[Throwable, AssetInfoFileContent] =


### PR DESCRIPTION
For some reason Sipi cannot transcode a valid jpx file and does so without logging an error. Sipi simply finishes without any output.
In order to complete the create originals for the other files we have to skip the file and log a warning and recreate those manually.