### PR TITLE
fix: Include folder name in mapping.csv in order to prevent collisions

### DIFF
--- a/src/main/scala/swiss/dasch/api/IngestEndpoint.scala
+++ b/src/main/scala/swiss/dasch/api/IngestEndpoint.scala
@@ -69,7 +69,7 @@ final case class BulkIngestServiceLive(
   override def startBulkIngest(project: ProjectShortcode): Task[IngestResult] =
     for {
       _          <- ZIO.logInfo(s"Starting bulk ingest for project $project")
-      importDir  <- storage.getTempDirectory().map(_ / "import" / project.value)
+      importDir  <- storage.getBulkIngestImportFolder(project)
       mappingFile = importDir.parent.head / s"mapping-$project.csv"
       _          <- (Files.createFile(mappingFile) *> Files.writeLines(mappingFile, List("original,derivative")))
                       .whenZIO(Files.exists(mappingFile).negate)
@@ -103,30 +103,34 @@ final case class BulkIngestServiceLive(
       csv: Path,
     ): Task[IngestResult] =
     for {
-      _               <- ZIO.logInfo(s"Ingesting image $file")
-      asset           <- Asset.makeNew(project)
-      assetDir        <- ensureAssetDirExists(asset)
-      originalFile    <- copyFileToAssetDir(file, assetDir, asset)
-      derivativeFile  <- transcode(assetDir, originalFile, asset)
-      originalFilename = file.filename.toString
-      _               <- assetInfo.createAssetInfo(asset, originalFilename)
-      _               <- updateMappingCsv(csv, derivativeFile, originalFilename, asset)
-      _               <- Files.delete(file)
-      _               <- ZIO.logInfo(s"Finished ingesting image $file")
+      _              <- ZIO.logInfo(s"Ingesting image $file")
+      asset          <- Asset.makeNew(project)
+      assetDir       <- ensureAssetDirExists(asset)
+      originalFile   <- copyFileToAssetDir(file, assetDir, asset)
+      derivativeFile <- transcode(assetDir, originalFile, asset)
+      _              <- assetInfo.createAssetInfo(asset, file.filename.toString)
+      _              <- updateMappingCsv(csv, derivativeFile, file, asset)
+      _              <- Files.delete(file)
+      _              <- ZIO.logInfo(s"Finished ingesting image $file")
     } yield IngestResult.success
 
   private def updateMappingCsv(
       mappingFile: Path,
       derivativeFile: Path,
-      originalFilename: String,
+      originalFile: Path,
       asset: Asset,
     ) =
-    ZIO.logInfo(s"Updating mapping file $mappingFile, $asset") *>
-      Files.writeLines(
-        mappingFile,
-        List(s"$originalFilename,${derivativeFile.filename}"),
-        openOptions = Set(StandardOpenOption.APPEND),
-      )
+    ZIO.logInfo(s"Updating mapping file $mappingFile, $asset") *> {
+      for {
+        importDir <- storage.getBulkIngestImportFolder(asset.belongsToProject)
+        original   = importDir.relativize(originalFile)
+        _         <- Files.writeLines(
+                       mappingFile,
+                       List(s"$original,${derivativeFile.filename}"),
+                       openOptions = Set(StandardOpenOption.APPEND),
+                     )
+      } yield ()
+    }
 
   private def ensureAssetDirExists(asset: Asset) =
     for {

--- a/src/main/scala/swiss/dasch/domain/StorageService.scala
+++ b/src/main/scala/swiss/dasch/domain/StorageService.scala
@@ -24,6 +24,8 @@ trait StorageService  {
   def getAssetDirectory(asset: Asset): UIO[Path]
   def getAssetDirectory(): UIO[Path]
   def getTempDirectory(): UIO[Path]
+  def getBulkIngestImportFolder(project: ProjectShortcode): UIO[Path] =
+    getTempDirectory().map(_ / "import" / project.toString)
   def createTempDirectoryScoped(directoryName: String, prefix: Option[String] = None): ZIO[Scope, IOException, Path]
   def loadJsonFile[A](file: Path)(implicit decoder: JsonDecoder[A]): Task[A]
   def saveJsonFile[A](file: Path, content: A)(implicit encoder: JsonEncoder[A]): Task[Unit]

--- a/src/main/scala/swiss/dasch/domain/StorageService.scala
+++ b/src/main/scala/swiss/dasch/domain/StorageService.scala
@@ -46,6 +46,8 @@ object StorageService {
     ZIO.serviceWithZIO[StorageService](_.getAssetDirectory())
   def getTempDirectory(): RIO[StorageService, Path]                                                                   =
     ZIO.serviceWithZIO[StorageService](_.getTempDirectory())
+  def getBulkIngestImportFolder(project: ProjectShortcode): RIO[StorageService, Path]                                 =
+    ZIO.serviceWithZIO[StorageService](_.getBulkIngestImportFolder(project))
   def createTempDirectoryScoped(directoryName: String, prefix: Option[String] = None)
       : ZIO[Scope with StorageService, IOException, Path] =
     ZIO.serviceWithZIO[StorageService](_.createTempDirectoryScoped(directoryName, prefix))

--- a/src/test/scala/swiss/dasch/domain/StorageServiceLiveSpec.scala
+++ b/src/test/scala/swiss/dasch/domain/StorageServiceLiveSpec.scala
@@ -49,6 +49,12 @@ object StorageServiceLiveSpec extends ZIOSpecDefault {
         actual   <- StorageService.getTempDirectory()
       } yield assertTrue(expected == actual)
     },
+    test("should return bulk ingest import folder") {
+      for {
+        expected <- ZIO.serviceWith[StorageConfig](_.tempPath)
+        actual   <- StorageService.getBulkIngestImportFolder(existingProject)
+      } yield assertTrue(actual == expected / "import" / existingProject.value)
+    },
     test("should return project directory") {
       for {
         expected <- ZIO.serviceWith[StorageConfig](_.assetPath).map(_ / existingProject.toString)


### PR DESCRIPTION
Should a file exist in a subfolder with the same name as another file we have to be able to distinguish these files in the mapping.csv. Include the folder path inside the import/<project_shortcode> as part of the original in the mapping.csv resolves this ambiguity.

The new content of the `mapping-<project_shortcode>.csv` file  would look like this:

```
original,derivative
100x100.png,75JdC5Idk6o-QjUEZWoAT3r.jpx
subfolder/100x100.png,1Ty6tYGtiMw-fxm9fbsvCV7.jpx
subfolder/subfolder2/100x100.png,3sILHLNzSfw-rbWPMoGmwEC.jpx
...
```

for an import folder like:

```
import/<project_shortcode>/
         ├── 100x100.png
         │ 
         └── subfolder/
                  ├── 100x100.png
                  │
                  └── subfolder2/
                           └── 100x100.png
```