### PR TITLE
chore: Add Java 21 to build and test DEV-2769

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v3
         with:
-          distribution: zulu
+          distribution: temurin
           java-version: ${{ matrix.java-version }}
           cache: sbt
       - name: Build and Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     name: Build and Run Tests
     strategy:
       matrix:
-        java-version: [ 17 ]
+        java-version: [ 17, 21 ]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current branch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v3
         with:
-          distribution: temurin
+          distribution: zulu
           java-version: ${{ matrix.java-version }}
           cache: sbt
       - name: Build and Test


### PR DESCRIPTION
Build and test project with Java 21 in parallel with Java 17.

Currently temurin [is publishing  their Java 21 for production use](https://github.com/adoptium/temurin/issues/8).

_Out of scope_
Use of Java 21 in published Docker artefact, this is still on Java 17. 