### PR TITLE
chore: Add Scala Steward configuration

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,70 @@
+# pullRequests.frequency allows to control how often or when Scala Steward
+# is allowed to create pull requests.
+#
+# Possible values:
+#   @asap
+#     PRs are created without delay.
+#
+#   <timespan>
+#     PRs are created only again after the given timespan since the last PR
+#     has passed. Example values are "36 hours", "1 day", or "14 days".
+
+#   <CRON expression>
+#     PRs are created roughly according to the given CRON expression.
+#
+#     CRON expressions consist of five fields:
+#     minutes, hour of day, day of month, month, and day of week.
+#
+#     See https://www.alonsodomin.me/cron4s/userguide/index.html#parsing for
+#     more information about the CRON expressions that are supported.
+#
+#     Note that the date parts of the CRON expression are matched exactly
+#     while the time parts are only used to abide to the frequency of
+#     the given expression.
+#
+# Default: "@asap"
+#
+#pullRequests.frequency = "0 0 ? * 3" # every thursday on midnight
+pullRequests.frequency = "7 days"
+
+# pullRequests.grouping allows you to specify how Scala Steward should group
+# your updates in order to reduce the number of pull-requests.
+#
+# Updates will be placed in the first group with which they match, starting
+# from the first in the array. Those that do not match any group will follow
+# the default procedure (one PR per update).
+#
+# Each element in the array will have the following schema:
+#
+#   - name (mandatory): the name of the group, will be used for things like naming the branch
+#   - title (optional): if provided it will be used as the title for the PR
+#   - filter (mandatory): a non-empty list containing the filters to use to know
+#                         if an update falls into this group.
+#
+# `filter` properties would have this format:
+#
+#    {
+#       version = "major" | "minor" | "patch" | "pre-release" | "build-metadata",
+#       group = "{group}",
+#       artifact = "{artifact}"
+#    }
+#
+# For more information on the values for the `version` filter visit https://semver.org/
+#
+# Every field in a `filter` is optional but at least one must be provided.
+#
+# For grouping every update together a filter like {group = "*"} can be # provided.
+#
+# To create a new PR for each unique combination of artifact-versions, include ${hash} in the name.
+#
+# Default: []
+pullRequests.grouping = [
+  { name = "patches", "title" = "Patch updates", "filter" = [{"version" = "patch"}] },
+  { name = "minor_major", "title" = "Minor/major updates", "filter" = [{"version" = "minor"}, {"version" = "major"}] },
+  { name = "all", "title" = "Dependency updates", "filter" = [{"group" = "*"}] }
+]
+
+# If set, Scala Steward will use this message template for the commit messages and PR titles.
+# Supported variables: ${artifactName}, ${currentVersion}, ${nextVersion} and ${default}
+# Default: "${default}" which is equivalent to "Update ${artifactName} to ${nextVersion}"
+commits.message = "chore: Update ${artifactName} from ${currentVersion} to ${nextVersion}"

--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -59,9 +59,9 @@ pullRequests.frequency = "7 days"
 #
 # Default: []
 pullRequests.grouping = [
-  { name = "patches", "title" = "Patch updates", "filter" = [{"version" = "patch"}] },
-  { name = "minor_major", "title" = "Minor/major updates", "filter" = [{"version" = "minor"}, {"version" = "major"}] },
-  { name = "all", "title" = "Dependency updates", "filter" = [{"group" = "*"}] }
+  { name = "patches", "title" = "chore: Patch updates", "filter" = [{"version" = "patch"}] },
+  { name = "minor_major", "title" = "chore: Minor/major updates", "filter" = [{"version" = "minor"}, {"version" = "major"}] },
+  { name = "all", "title" = "chore: Dependency updates", "filter" = [{"group" = "*"}] }
 ]
 
 # If set, Scala Steward will use this message template for the commit messages and PR titles.


### PR DESCRIPTION
PRs are created only again after the seven days since the last PR.

Scala Steward should group should group updates in order to reduce the number of pull-requests. Three groups: patch version updates, minor/major version updated, everything else.

Start every commit message with `chore: ` in order to comply with our rules.
