### PR TITLE
chore: Force PR titles to start with an upper case letter

### DIFF
--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -11,5 +11,5 @@ jobs:
     steps:
       - uses: deepakputhraya/action-pr-title@master
         with:
-          regex: '^(feat|fix|build|chore|test|refactor|docs)(\(.+\))?!?: .+$'
+          regex: '^(feat|fix|build|chore|test|refactor|docs)(\(.+\))?!?: [A-Z].+$'
           max_length: 140

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -17,6 +17,7 @@ jobs:
         with:
           token: ${{ secrets.GH_TOKEN }}
           package-name: dsp-ingest
+          pull-request-title-pattern: "chore${{ scope }}: Release ${{ version }}"
           release-type: simple
           changelog-types: '[
                        {"type": "feat", "section": "Enhancements", "hidden": false },

--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -59,9 +59,9 @@ pullRequests.frequency = "7 days"
 #
 # Default: []
 pullRequests.grouping = [
-  { name = "patches", "title" = "chore: Patch updates", "filter" = [{"version" = "patch"}] },
-  { name = "minor_major", "title" = "chore: Minor/major updates", "filter" = [{"version" = "minor"}, {"version" = "major"}] },
-  { name = "all", "title" = "chore: Dependency updates", "filter" = [{"group" = "*"}] }
+  {name = "patches", "title" = "chore: Dependency patch updates", "filter" = [{"version" = "patch"}]},
+  {name = "minor_major", "title" = "chore: Dependency minor/major updates", "filter" = [{"version" = "minor"}, {"version" = "major"}]},
+  {name = "all", "title" = "chore: Dependency updates", "filter" = [{"group" = "*"}]}
 ]
 
 # If set, Scala Steward will use this message template for the commit messages and PR titles.


### PR DESCRIPTION
Update release please and scala steward PR titles.

Forcing an initial upper case letter will let the release please generated release notes look more consistent than with mixed case titles.