### PR TITLE
chore(scala-steward): Improve dependency grouping 

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -59,8 +59,9 @@ pullRequests.frequency = "7 days"
 #
 # Default: []
 pullRequests.grouping = [
-  {name = "patches", "title" = "chore: Dependency patch updates", "filter" = [{"version" = "patch"}]},
-  {name = "minor_major", "title" = "chore: Dependency minor/major updates", "filter" = [{"version" = "minor"}, {"version" = "major"}]},
+  { name = "patch", "title" = "chore: Patch dependency updates", "filter" = [{"version" = "patch"}] },
+  { name = "minor", "title" = "chore: Minor dependency updates", "filter" = [{"version" = "minor"}] },
+  { name = "major", "title" = "chore: Major dependency updates", "filter" = [{"version" = "major"}] },
   {name = "all", "title" = "chore: Dependency updates", "filter" = [{"group" = "*"}]}
 ]
 

--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -24,9 +24,6 @@
 #
 # Default: "@asap"
 #
-#pullRequests.frequency = "0 0 ? * 3" # every thursday on midnight
-pullRequests.frequency = "7 days"
-
 # pullRequests.grouping allows you to specify how Scala Steward should group
 # your updates in order to reduce the number of pull-requests.
 #

--- a/build.sbt
+++ b/build.sbt
@@ -10,16 +10,16 @@ addCommandAlias("headerCreateAll", "; all root/headerCreate Test/headerCreate")
 addCommandAlias("headerCheckAll", "; all root/headerCheck Test/headerCheck")
 
 val tapirVersion                = "1.8.4"
-val zioVersion                  = "2.0.18"
-val zioJsonVersion              = "0.6.2"
-val zioConfigVersion            = "3.0.7"
-val zioLoggingVersion           = "2.1.14"
 val testContainersVersion       = "0.40.15"
+val zioConfigVersion            = "3.0.7"
+val zioHttpVersion              = "3.0.0-RC2"
+val zioJsonVersion              = "0.6.2"
+val zioLoggingVersion           = "2.1.14"
 val zioMetricsConnectorsVersion = "2.2.1"
 val zioMockVersion              = "1.0.0-RC11"
 val zioNioVersion               = "2.0.2"
 val zioPreludeVersion           = "1.0.0-RC21"
-val zioHttpVersion              = "3.0.0-RC2"
+val zioVersion                  = "2.0.18"
 
 val gitCommit  = ("git rev-parse HEAD" !!).trim
 val gitVersion = ("git describe --tag --dirty --abbrev=7 --always  " !!).trim
@@ -33,15 +33,16 @@ ThisBuild / semanticdbEnabled := true
 scalacOptions ++= Seq("-old-syntax", "-rewrite")
 
 val tapir = Seq(
-  "com.softwaremill.sttp.tapir" %% "tapir-zio-http-server"   % tapirVersion,
   "com.softwaremill.sttp.tapir" %% "tapir-json-zio"          % tapirVersion,
+  "com.softwaremill.sttp.tapir" %% "tapir-refined"           % tapirVersion,
   "com.softwaremill.sttp.tapir" %% "tapir-swagger-ui-bundle" % tapirVersion,
-  "com.softwaremill.sttp.tapir" %% "tapir-refined"           % "1.8.4"
+  "com.softwaremill.sttp.tapir" %% "tapir-zio-http-server"   % tapirVersion
 )
+
 val metrics = Seq(
+  "com.softwaremill.sttp.tapir" %% "tapir-zio-metrics"                 % tapirVersion,
   "dev.zio"                     %% "zio-metrics-connectors"            % zioMetricsConnectorsVersion,
-  "dev.zio"                     %% "zio-metrics-connectors-prometheus" % zioMetricsConnectorsVersion,
-  "com.softwaremill.sttp.tapir" %% "tapir-zio-metrics"                 % "1.8.4"
+  "dev.zio"                     %% "zio-metrics-connectors-prometheus" % zioMetricsConnectorsVersion
 )
 
 lazy val root = (project in file("."))
@@ -67,21 +68,21 @@ lazy val root = (project in file("."))
       )
     ),
     libraryDependencies ++= tapir ++ metrics ++ Seq(
+      "com.github.jwt-scala" %% "jwt-zio-json"                      % "9.4.4",
+      "commons-io"            % "commons-io"                        % "2.15.0",
       "dev.zio"              %% "zio"                               % zioVersion,
       "dev.zio"              %% "zio-config"                        % zioConfigVersion,
       "dev.zio"              %% "zio-config-magnolia"               % zioConfigVersion,
       "dev.zio"              %% "zio-config-typesafe"               % zioConfigVersion,
       "dev.zio"              %% "zio-http"                          % zioHttpVersion,
       "dev.zio"              %% "zio-json"                          % zioJsonVersion,
-      "dev.zio"              %% "zio-json-interop-refined"          % "0.6.2",
+      "dev.zio"              %% "zio-json-interop-refined"          % zioJsonVersion,
       "dev.zio"              %% "zio-metrics-connectors"            % zioMetricsConnectorsVersion,
       "dev.zio"              %% "zio-metrics-connectors-prometheus" % zioMetricsConnectorsVersion,
       "dev.zio"              %% "zio-nio"                           % zioNioVersion,
       "dev.zio"              %% "zio-prelude"                       % zioPreludeVersion,
       "dev.zio"              %% "zio-streams"                       % zioVersion,
       "eu.timepit"           %% "refined"                           % "0.11.0",
-      "commons-io"            % "commons-io"                        % "2.15.0",
-      "com.github.jwt-scala" %% "jwt-zio-json"                      % "9.4.4",
       // add the silencer lib for scala 2.13 in order to compile with scala 3.3.0 until https://github.com/zio/zio-config/pull/1171 is merged
       // resolves problems when `sbt doc` failed with
       // [error] -- Error: typesafe/shared/src/main/scala/zio/config/typesafe/TypesafeConfigSource.scala:15:0
@@ -93,11 +94,11 @@ lazy val root = (project in file("."))
       "dev.zio" %% "zio-logging-slf4j2-bridge" % zioLoggingVersion,
 
       // test
-      "dev.zio"      %% "zio-test"               % zioVersion     % Test,
-      "dev.zio"      %% "zio-test-sbt"           % zioVersion     % Test,
-      "dev.zio"      %% "zio-test-junit"         % zioVersion     % Test,
       "dev.zio"      %% "zio-mock"               % zioMockVersion % Test,
+      "dev.zio"      %% "zio-test"               % zioVersion     % Test,
+      "dev.zio"      %% "zio-test-junit"         % zioVersion     % Test,
       "dev.zio"      %% "zio-test-magnolia"      % zioVersion     % Test,
+      "dev.zio"      %% "zio-test-sbt"           % zioVersion     % Test,
       "org.scoverage" % "sbt-scoverage_2.12_1.0" % "2.0.9"        % Test
     ),
     testFrameworks                       := Seq(new TestFramework("zio.test.sbt.ZTestFramework")),


### PR DESCRIPTION
This PR:
- improves dependency grouping to as it is now in dsp-ap,
- changes the frequency of updates, from every 7 days, to twice per week (defined in `scala-steward.yml` file),
- cleans up `build.sbt` file.