### PR TITLE
fix: Ingest fails when mapping file folder does not exist (DEV-3055)

### DIFF
--- a/src/main/scala/swiss/dasch/domain/BulkIngestService.scala
+++ b/src/main/scala/swiss/dasch/domain/BulkIngestService.scala
@@ -12,6 +12,7 @@ import zio.nio.file.{Files, Path}
 import java.nio.file.StandardOpenOption
 import eu.timepit.refined.types.string.NonEmptyString
 import swiss.dasch.domain.ComplexAsset.ImageAsset
+import java.io.IOException
 
 trait BulkIngestService {
 
@@ -44,6 +45,7 @@ final case class BulkIngestServiceLive(
     for {
       _           <- ZIO.logInfo(s"Starting bulk ingest for project $project")
       importDir   <- storage.getBulkIngestImportFolder(project)
+      _           <- ZIO.fail(new IOException(s"Import directory '$importDir' does not exist")).unlessZIO(Files.exists(importDir))
       mappingFile <- storage.createBulkIngestMappingFile(project)
       _           <- ZIO.logInfo(s"Import dir: $importDir, mapping file: $mappingFile")
       total       <- StorageService.findInPath(importDir, FileFilters.isNonHiddenRegularFile).runCount

--- a/src/main/scala/swiss/dasch/domain/StorageService.scala
+++ b/src/main/scala/swiss/dasch/domain/StorageService.scala
@@ -26,6 +26,7 @@ trait StorageService {
   def createOriginalFileInAssetDir(file: Path, asset: AssetRef): IO[IOException, OriginalFile]
   def getTempDirectory(): UIO[Path]
   def getBulkIngestImportFolder(project: ProjectShortcode): UIO[Path]
+  def createBulkIngestMappingFile(project: ProjectShortcode): Task[Path]
   def createTempDirectoryScoped(directoryName: String, prefix: Option[String] = None): ZIO[Scope, IOException, Path]
   def loadJsonFile[A](file: Path)(implicit decoder: JsonDecoder[A]): Task[A]
   def saveJsonFile[A](file: Path, content: A)(implicit encoder: JsonEncoder[A]): Task[Unit]
@@ -50,6 +51,8 @@ object StorageService {
     ZIO.serviceWithZIO[StorageService](_.getTempDirectory())
   def getBulkIngestImportFolder(project: ProjectShortcode): RIO[StorageService, Path] =
     ZIO.serviceWithZIO[StorageService](_.getBulkIngestImportFolder(project))
+  def createBulkIngestMappingFile(project: ProjectShortcode): ZIO[StorageService, Throwable, Path] =
+    ZIO.serviceWithZIO[StorageService](_.createBulkIngestMappingFile(project))
   def createTempDirectoryScoped(
     directoryName: String,
     prefix: Option[String] = None
@@ -78,6 +81,14 @@ final case class StorageServiceLive(config: StorageConfig) extends StorageServic
 
   override def getBulkIngestImportFolder(project: ProjectShortcode): UIO[Path] =
     getTempDirectory().map(_ / "import" / project.toString)
+
+  override def createBulkIngestMappingFile(project: ProjectShortcode): Task[Path] = for {
+    mappingDir <- getBulkIngestImportFolder(project).map(_.parent.head)
+    mappingFile = mappingDir / s"mapping-$project.csv"
+    _          <- Files.createDirectories(mappingDir).unlessZIO(Files.exists(mappingDir))
+    _ <- (Files.createFile(mappingFile) *> Files.writeLines(mappingFile, List("original,derivative")))
+           .unlessZIO(Files.exists(mappingFile))
+  } yield mappingFile
 
   override def getAssetDirectory(): UIO[Path] =
     ZIO.succeed(config.assetPath)

--- a/src/main/scala/swiss/dasch/domain/StorageService.scala
+++ b/src/main/scala/swiss/dasch/domain/StorageService.scala
@@ -85,7 +85,6 @@ final case class StorageServiceLive(config: StorageConfig) extends StorageServic
   override def createBulkIngestMappingFile(project: ProjectShortcode): Task[Path] = for {
     mappingDir <- getBulkIngestImportFolder(project).map(_.parent.head)
     mappingFile = mappingDir / s"mapping-$project.csv"
-    _          <- Files.createDirectories(mappingDir).unlessZIO(Files.exists(mappingDir))
     _ <- (Files.createFile(mappingFile) *> Files.writeLines(mappingFile, List("original,derivative")))
            .unlessZIO(Files.exists(mappingFile))
   } yield mappingFile


### PR DESCRIPTION
Actually a non-issue which should not occur unless the image files to be ingested are in the wrong place. But I only found this out after I did the work and it still improves the code, so I'd merge it anyways, if that's ok.