### PR TITLE
refactor: Extract IngestService

### DIFF
--- a/src/main/scala/swiss/dasch/Main.scala
+++ b/src/main/scala/swiss/dasch/Main.scala
@@ -39,6 +39,7 @@ object Main extends ZIOAppDefault {
         HealthCheckServiceLive.layer,
         ImportServiceLive.layer,
         ImageServiceLive.layer,
+        IngestService.layer,
         IngestApiServer.layer,
         MaintenanceEndpoints.layer,
         MaintenanceEndpointsHandler.layer,

--- a/src/main/scala/swiss/dasch/domain/AssetModel.scala
+++ b/src/main/scala/swiss/dasch/domain/AssetModel.scala
@@ -118,7 +118,7 @@ object DerivativeFile {
     def from(file: Path): Option[OtherDerivativeFile] =
       file match {
         case hidden if hidden.filename.toString.startsWith(".") => None
-        case other if Other.extensions.contains(other.filename.fileExtension) =>
+        case other if Other.acceptsExtension(other.filename.fileExtension) =>
           hasAssetIdInFilename(other).map(OtherDerivativeFile(_))
         case _ => None
       }

--- a/src/main/scala/swiss/dasch/domain/IngestService.scala
+++ b/src/main/scala/swiss/dasch/domain/IngestService.scala
@@ -25,7 +25,7 @@ final case class IngestService(
   def ingestFile(fileToIngest: Path, project: ProjectShortcode): Task[Asset] =
     for {
       _ <- ZIO.logInfo(s"Ingesting file $fileToIngest")
-      _ <- ZIO.whenZIO(FileFilters.isSupported(fileToIngest).negate)(
+      _ <- ZIO.unlessZIO(FileFilters.isSupported(fileToIngest))(
              ZIO.fail(new IllegalArgumentException(s"File $fileToIngest is not a supported file."))
            )
       assetRef <- AssetRef.makeNew(project)

--- a/src/main/scala/swiss/dasch/domain/IngestService.scala
+++ b/src/main/scala/swiss/dasch/domain/IngestService.scala
@@ -73,5 +73,9 @@ final case class IngestService(
 }
 
 object IngestService {
+
+  def ingestFile(fileToIngest: Path, project: ProjectShortcode): ZIO[IngestService, Throwable, Asset] =
+    ZIO.serviceWithZIO[IngestService](_.ingestFile(fileToIngest, project))
+
   def layer = ZLayer.derive[IngestService]
 }

--- a/src/main/scala/swiss/dasch/domain/IngestService.scala
+++ b/src/main/scala/swiss/dasch/domain/IngestService.scala
@@ -12,51 +12,49 @@ import swiss.dasch.domain.PathOps.fileExtension
 import zio.nio.file.Path
 import zio.{IO, Task, ZIO, ZLayer}
 
-import java.io.{FileNotFoundException, IOException}
+import java.io.IOException
 
-final case class IngestedFile()
 final case class IngestService(
   storage: StorageService,
   imageService: ImageService,
   sipiClient: SipiClient,
   assetInfo: AssetInfoService
 ) {
-  def ingestFile(
-    fileToIngest: Path,
-    project: ProjectShortcode
-  ): Task[Asset] =
+
+  def ingestFile(fileToIngest: Path, project: ProjectShortcode): Task[Asset] =
     for {
-      _        <- ZIO.logInfo(s"Ingesting file $fileToIngest")
-      assetRef <- AssetRef.makeNew(project)
-      _ <- ZIO.whenZIO(FileFilters.isNonHiddenRegularFile(fileToIngest).negate)(
-             ZIO.fail(new FileNotFoundException(s"File $fileToIngest is not a regular file"))
+      _ <- ZIO.logInfo(s"Ingesting file $fileToIngest")
+      _ <- ZIO.whenZIO(FileFilters.isSupported(fileToIngest).negate)(
+             ZIO.fail(new IllegalArgumentException(s"File $fileToIngest is not a supported file."))
            )
-      _        <- storage.getAssetDirectory(assetRef).tap(storage.createDirectories(_))
-      original <- createOriginalFileInAssetDir(fileToIngest, assetRef)
+      assetRef <- AssetRef.makeNew(project)
+      assetDir <- ensureAssetDirectoryExists(assetRef)
+      original <- createOriginalFileInAssetDir(fileToIngest, assetRef, assetDir)
       asset <- ZIO
                  .fromOption(SupportedFileType.fromPath(fileToIngest))
                  .orElseFail(new IllegalArgumentException("Unsupported file type."))
-                 .flatMap { it =>
-                   it match {
-                     case SupportedFileType.StillImage => handleImageFile(original, assetRef)
-                     case SupportedFileType.Other      => handleOtherFile(original, assetRef)
-                     case SupportedFileType.MovingImage =>
-                       ZIO.fail(new NotImplementedError("Video files are not supported yet."))
-                   }
+                 .flatMap {
+                   case SupportedFileType.StillImage => handleImageFile(original, assetRef)
+                   case SupportedFileType.Other      => handleOtherFile(original, assetRef, assetDir)
+                   case SupportedFileType.MovingImage =>
+                     ZIO.fail(new NotImplementedError("Video files are not supported yet."))
                  }
       _ <- assetInfo.createAssetInfo(asset)
       _ <- storage.delete(fileToIngest)
       _ <- ZIO.logInfo(s"Finished ingesting file $fileToIngest")
     } yield asset
 
-  private def createOriginalFileInAssetDir(file: Path, assetRef: AssetRef): IO[IOException, Original] = for {
-    _               <- ZIO.logInfo(s"Creating original for $file, $assetRef")
-    assetDir        <- storage.getAssetDirectory(assetRef)
-    originalPath     = assetDir / s"${assetRef.id}.${file.fileExtension}.orig"
-    _               <- storage.copyFile(file, originalPath)
-    originalFile     = OriginalFile.unsafeFrom(originalPath)
-    originalFileName = NonEmptyString.unsafeFrom(file.filename.toString)
-  } yield Original(originalFile, originalFileName)
+  private def ensureAssetDirectoryExists(assetRef: AssetRef): IO[IOException, Path] =
+    storage.getAssetDirectory(assetRef).tap(storage.createDirectories(_))
+
+  private def createOriginalFileInAssetDir(file: Path, assetRef: AssetRef, assetDir: Path): IO[IOException, Original] =
+    for {
+      _               <- ZIO.logInfo(s"Creating original for $file, $assetRef")
+      originalPath     = assetDir / s"${assetRef.id}.${file.fileExtension}.orig"
+      _               <- storage.copyFile(file, originalPath)
+      originalFile     = OriginalFile.unsafeFrom(originalPath)
+      originalFileName = NonEmptyString.unsafeFrom(file.filename.toString)
+    } yield Original(originalFile, originalFileName)
 
   private def handleImageFile(original: Original, assetRef: AssetRef): Task[StillImageAsset] =
     ZIO.logInfo(s"Creating derivative for image $original, $assetRef") *>
@@ -64,17 +62,14 @@ final case class IngestService(
         .createDerivative(original.file)
         .map(derivative => Asset.makeStillImage(assetRef, original, derivative))
 
-  private def handleOtherFile(original: Original, assetRef: AssetRef): Task[OtherAsset] = {
-    def createDerivative(original: Original) =
-      for {
-        folder        <- storage.getAssetDirectory(assetRef)
-        derivativePath = folder / s"${assetRef.id}.${original.file.toPath.fileExtension}"
-        _             <- storage.copyFile(original.file.toPath, derivativePath)
-      } yield OtherDerivativeFile.unsafeFrom(derivativePath)
-
-    ZIO.logInfo(s"Creating derivative for other $original, $assetRef") *>
-      createDerivative(original).map(derivative => Asset.makeOther(assetRef, original, derivative))
-  }
+  private def handleOtherFile(original: Original, assetRef: AssetRef, assetDir: Path): Task[OtherAsset] =
+    ZIO.logInfo(s"Creating derivative for other $original, $assetRef") *> {
+      val derivativePath = assetDir / s"${assetRef.id}.${original.file.toPath.fileExtension}"
+      storage
+        .copyFile(original.file.toPath, derivativePath)
+        .as(OtherDerivativeFile.unsafeFrom(derivativePath))
+        .map(derivative => Asset.makeOther(assetRef, original, derivative))
+    }
 }
 
 object IngestService {

--- a/src/main/scala/swiss/dasch/domain/IngestService.scala
+++ b/src/main/scala/swiss/dasch/domain/IngestService.scala
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2021 - 2023 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package swiss.dasch.domain
+
+import eu.timepit.refined.types.string.NonEmptyString
+import swiss.dasch.domain.Asset.{OtherAsset, StillImageAsset}
+import swiss.dasch.domain.DerivativeFile.OtherDerivativeFile
+import swiss.dasch.domain.PathOps.fileExtension
+import zio.nio.file.Path
+import zio.{IO, Task, ZIO, ZLayer}
+
+import java.io.{FileNotFoundException, IOException}
+
+final case class IngestedFile()
+final case class IngestService(
+  storage: StorageService,
+  imageService: ImageService,
+  sipiClient: SipiClient,
+  assetInfo: AssetInfoService
+) {
+  def ingestFile(
+    fileToIngest: Path,
+    project: ProjectShortcode
+  ): Task[Asset] =
+    for {
+      _        <- ZIO.logInfo(s"Ingesting file $fileToIngest")
+      assetRef <- AssetRef.makeNew(project)
+      _ <- ZIO.whenZIO(FileFilters.isNonHiddenRegularFile(fileToIngest).negate)(
+             ZIO.fail(new FileNotFoundException(s"File $fileToIngest is not a regular file"))
+           )
+      _        <- storage.getAssetDirectory(assetRef).tap(storage.createDirectories(_))
+      original <- createOriginalFileInAssetDir(fileToIngest, assetRef)
+      asset <- ZIO
+                 .fromOption(SupportedFileType.fromPath(fileToIngest))
+                 .orElseFail(new IllegalArgumentException("Unsupported file type."))
+                 .flatMap { it =>
+                   it match {
+                     case SupportedFileType.StillImage => handleImageFile(original, assetRef)
+                     case SupportedFileType.Other      => handleOtherFile(original, assetRef)
+                     case SupportedFileType.MovingImage =>
+                       ZIO.fail(new NotImplementedError("Video files are not supported yet."))
+                   }
+                 }
+      _ <- assetInfo.createAssetInfo(asset)
+      _ <- storage.delete(fileToIngest)
+      _ <- ZIO.logInfo(s"Finished ingesting file $fileToIngest")
+    } yield asset
+
+  private def createOriginalFileInAssetDir(file: Path, assetRef: AssetRef): IO[IOException, Original] = for {
+    _               <- ZIO.logInfo(s"Creating original for $file, $assetRef")
+    assetDir        <- storage.getAssetDirectory(assetRef)
+    originalPath     = assetDir / s"${assetRef.id}.${file.fileExtension}.orig"
+    _               <- storage.copyFile(file, originalPath)
+    originalFile     = OriginalFile.unsafeFrom(originalPath)
+    originalFileName = NonEmptyString.unsafeFrom(file.filename.toString)
+  } yield Original(originalFile, originalFileName)
+
+  private def handleImageFile(original: Original, assetRef: AssetRef): Task[StillImageAsset] =
+    ZIO.logInfo(s"Creating derivative for image $original, $assetRef") *>
+      imageService
+        .createDerivative(original.file)
+        .map(derivative => Asset.makeStillImage(assetRef, original, derivative))
+
+  private def handleOtherFile(original: Original, assetRef: AssetRef): Task[OtherAsset] = {
+    def createDerivative(original: Original) =
+      for {
+        folder        <- storage.getAssetDirectory(assetRef)
+        derivativePath = folder / s"${assetRef.id}.${original.file.toPath.fileExtension}"
+        _             <- storage.copyFile(original.file.toPath, derivativePath)
+      } yield OtherDerivativeFile.unsafeFrom(derivativePath)
+
+    ZIO.logInfo(s"Creating derivative for other $original, $assetRef") *>
+      createDerivative(original).map(derivative => Asset.makeOther(assetRef, original, derivative))
+  }
+}
+
+object IngestService {
+  def layer = ZLayer.derive[IngestService]
+}

--- a/src/main/scala/swiss/dasch/domain/IngestService.scala
+++ b/src/main/scala/swiss/dasch/domain/IngestService.scala
@@ -6,6 +6,7 @@
 package swiss.dasch.domain
 
 import eu.timepit.refined.types.string.NonEmptyString
+import org.apache.commons.io.FilenameUtils
 import swiss.dasch.domain.Asset.{OtherAsset, StillImageAsset}
 import swiss.dasch.domain.DerivativeFile.OtherDerivativeFile
 import swiss.dasch.domain.PathOps.fileExtension
@@ -64,11 +65,10 @@ final case class IngestService(
 
   private def handleOtherFile(original: Original, assetRef: AssetRef, assetDir: Path): Task[OtherAsset] =
     ZIO.logInfo(s"Creating derivative for other $original, $assetRef") *> {
-      val derivativePath = assetDir / s"${assetRef.id}.${original.file.toPath.fileExtension}"
-      storage
-        .copyFile(original.file.toPath, derivativePath)
-        .as(OtherDerivativeFile.unsafeFrom(derivativePath))
-        .map(derivative => Asset.makeOther(assetRef, original, derivative))
+      val fileExtension  = FilenameUtils.getExtension(original.originalFilename.toString)
+      val derivativePath = assetDir / s"${assetRef.id}.$fileExtension"
+      val derivative     = OtherDerivativeFile.unsafeFrom(derivativePath)
+      storage.copyFile(original.file.toPath, derivativePath).as(Asset.makeOther(assetRef, original, derivative))
     }
 }
 

--- a/src/main/scala/swiss/dasch/domain/StorageService.scala
+++ b/src/main/scala/swiss/dasch/domain/StorageService.scala
@@ -14,6 +14,7 @@ import zio.stream.ZStream
 
 import java.io.IOException
 import java.nio.file.StandardOpenOption.*
+import java.nio.file.attribute.FileAttribute
 import java.nio.file.{CopyOption, OpenOption, StandardOpenOption}
 import java.text.ParseException
 import java.time.format.DateTimeFormatter
@@ -29,8 +30,12 @@ trait StorageService {
   def createTempDirectoryScoped(directoryName: String, prefix: Option[String] = None): ZIO[Scope, IOException, Path]
   def loadJsonFile[A](file: Path)(implicit decoder: JsonDecoder[A]): Task[A]
   def saveJsonFile[A](file: Path, content: A)(implicit encoder: JsonEncoder[A]): Task[Unit]
-  def copyFile(source: Path, target: Path, copyOption: CopyOption*): ZIO[Any, IOException, Unit] =
+  final def copyFile(source: Path, target: Path, copyOption: CopyOption*): IO[IOException, Unit] =
     Files.copy(source, target, copyOption: _*)
+  final def createDirectories(path: Path, attrs: FileAttribute[_]*): IO[IOException, Unit] =
+    Files.createDirectories(path, attrs: _*)
+  final def delete(path: Path): IO[IOException, Unit] =
+    Files.delete(path)
 }
 
 object StorageService {

--- a/src/main/scala/swiss/dasch/domain/StorageService.scala
+++ b/src/main/scala/swiss/dasch/domain/StorageService.scala
@@ -25,17 +25,12 @@ trait StorageService {
   def getAssetDirectory(asset: AssetRef): UIO[Path]
   def getAssetDirectory(): UIO[Path]
   def getTempDirectory(): UIO[Path]
-  def getBulkIngestImportFolder(project: ProjectShortcode): UIO[Path]
-  def createBulkIngestMappingFile(project: ProjectShortcode): Task[Path]
   def createTempDirectoryScoped(directoryName: String, prefix: Option[String] = None): ZIO[Scope, IOException, Path]
   def loadJsonFile[A](file: Path)(implicit decoder: JsonDecoder[A]): Task[A]
   def saveJsonFile[A](file: Path, content: A)(implicit encoder: JsonEncoder[A]): Task[Unit]
-  final def copyFile(source: Path, target: Path, copyOption: CopyOption*): IO[IOException, Unit] =
-    Files.copy(source, target, copyOption: _*)
-  final def createDirectories(path: Path, attrs: FileAttribute[_]*): IO[IOException, Unit] =
-    Files.createDirectories(path, attrs: _*)
-  final def delete(path: Path): IO[IOException, Unit] =
-    Files.delete(path)
+  def copyFile(source: Path, target: Path, copyOption: CopyOption*): IO[IOException, Unit]
+  def createDirectories(path: Path, attrs: FileAttribute[_]*): IO[IOException, Unit]
+  def delete(path: Path): IO[IOException, Unit]
 }
 
 object StorageService {
@@ -54,10 +49,6 @@ object StorageService {
     ZIO.serviceWithZIO[StorageService](_.getAssetDirectory())
   def getTempDirectory(): RIO[StorageService, Path] =
     ZIO.serviceWithZIO[StorageService](_.getTempDirectory())
-  def getBulkIngestImportFolder(project: ProjectShortcode): RIO[StorageService, Path] =
-    ZIO.serviceWithZIO[StorageService](_.getBulkIngestImportFolder(project))
-  def createBulkIngestMappingFile(project: ProjectShortcode): ZIO[StorageService, Throwable, Path] =
-    ZIO.serviceWithZIO[StorageService](_.createBulkIngestMappingFile(project))
   def createTempDirectoryScoped(
     directoryName: String,
     prefix: Option[String] = None
@@ -73,16 +64,6 @@ final case class StorageServiceLive(config: StorageConfig) extends StorageServic
 
   override def getTempDirectory(): UIO[Path] =
     ZIO.succeed(config.tempPath)
-
-  override def getBulkIngestImportFolder(project: ProjectShortcode): UIO[Path] =
-    getTempDirectory().map(_ / "import" / project.toString)
-
-  override def createBulkIngestMappingFile(project: ProjectShortcode): Task[Path] = for {
-    mappingDir <- getBulkIngestImportFolder(project).map(_.parent.head)
-    mappingFile = mappingDir / s"mapping-$project.csv"
-    _ <- (Files.createFile(mappingFile) *> Files.writeLines(mappingFile, List("original,derivative")))
-           .unlessZIO(Files.exists(mappingFile))
-  } yield mappingFile
 
   override def getAssetDirectory(): UIO[Path] =
     ZIO.succeed(config.assetPath)
@@ -127,6 +108,15 @@ final case class StorageServiceLive(config: StorageConfig) extends StorageServic
     val bytes = Chunk.fromIterable((content.toJsonPretty + "\n").getBytes)
     Files.writeBytes(file, bytes, CREATE, WRITE, TRUNCATE_EXISTING)
   }
+
+  override def copyFile(source: Path, target: Path, copyOption: CopyOption*): IO[IOException, Unit] =
+    Files.copy(source, target, copyOption: _*)
+
+  override def createDirectories(path: Path, attrs: FileAttribute[_]*): IO[IOException, Unit] =
+    Files.createDirectories(path, attrs: _*)
+
+  override def delete(path: Path): IO[IOException, Unit] =
+    Files.delete(path)
 }
 object StorageServiceLive {
   val layer: URLayer[StorageConfig, StorageService] = ZLayer.derive[StorageServiceLive]

--- a/src/main/scala/swiss/dasch/domain/SupportedFileType.scala
+++ b/src/main/scala/swiss/dasch/domain/SupportedFileType.scala
@@ -31,5 +31,5 @@ enum SupportedFileType(val extensions: Seq[String]) {
 object SupportedFileType {
 
   def fromPath(path: Path): Option[SupportedFileType] =
-    SupportedFileType.values.find(_.extensions.exists(path.fileExtension.equalsIgnoreCase(_)))
+    SupportedFileType.values.find(_.acceptsExtension(path.fileExtension))
 }

--- a/src/main/scala/swiss/dasch/domain/SupportedFileType.scala
+++ b/src/main/scala/swiss/dasch/domain/SupportedFileType.scala
@@ -24,6 +24,8 @@ enum SupportedFileType(val extensions: Seq[String]) {
   case StillImage  extends SupportedFileType(SipiImageFormat.allExtensions)
   case MovingImage extends SupportedFileType(Seq("mp4"))
   case Other       extends SupportedFileType(archive ++ audio ++ office ++ tables ++ text)
+
+  def acceptsExtension(extension: String): Boolean = extensions.exists(extension.equalsIgnoreCase)
 }
 
 object SupportedFileType {

--- a/src/main/scala/swiss/dasch/domain/SupportedFileType.scala
+++ b/src/main/scala/swiss/dasch/domain/SupportedFileType.scala
@@ -4,8 +4,8 @@
  */
 
 package swiss.dasch.domain
+
 import swiss.dasch.domain.PathOps.fileExtension
-import zio.*
 import zio.nio.file.Path
 
 private val archive = Seq("7z", "gz", "gzip", "tar", "tar.gz", "tgz", "z", "zip")

--- a/src/test/scala/swiss/dasch/api/ProjectsEndpointSpec.scala
+++ b/src/test/scala/swiss/dasch/api/ProjectsEndpointSpec.scala
@@ -174,6 +174,7 @@ object ProjectsEndpointSpec extends ZIOSpecDefault {
     FileChecksumServiceLive.layer,
     ImageServiceLive.layer,
     ImportServiceLive.layer,
+    IngestService.layer,
     ProjectServiceLive.layer,
     ProjectsEndpoints.layer,
     ProjectsEndpointsHandler.layer,

--- a/src/test/scala/swiss/dasch/domain/IngestServiceSpec.scala
+++ b/src/test/scala/swiss/dasch/domain/IngestServiceSpec.scala
@@ -1,3 +1,8 @@
+/*
+ * Copyright © 2021 - 2023 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package swiss.dasch.domain
 
 import swiss.dasch.api.SipiClientMock

--- a/src/test/scala/swiss/dasch/domain/IngestServiceSpec.scala
+++ b/src/test/scala/swiss/dasch/domain/IngestServiceSpec.scala
@@ -33,7 +33,7 @@ object IngestServiceSpec extends ZIOSpecDefault {
         derivativeExists  <- Files.exists(assetDir / derivativeFilename)
       } yield assertTrue(
         asset.belongsToProject == shortcode,
-        info.originalFilename == fileToIngest.filename,
+        info.originalFilename.toString == fileToIngest.filename.toStrin.toStringg,
         info.originalFilename == asset.original.originalFilename,
         info.asset == asset.ref,
         info.original.checksum == checksum,

--- a/src/test/scala/swiss/dasch/domain/IngestServiceSpec.scala
+++ b/src/test/scala/swiss/dasch/domain/IngestServiceSpec.scala
@@ -33,7 +33,7 @@ object IngestServiceSpec extends ZIOSpecDefault {
         derivativeExists  <- Files.exists(assetDir / derivativeFilename)
       } yield assertTrue(
         asset.belongsToProject == shortcode,
-        info.originalFilename.toString == "test.csv",
+        info.originalFilename == fileToIngest.filename,
         info.originalFilename == asset.original.originalFilename,
         info.asset == asset.ref,
         info.original.checksum == checksum,

--- a/src/test/scala/swiss/dasch/domain/IngestServiceSpec.scala
+++ b/src/test/scala/swiss/dasch/domain/IngestServiceSpec.scala
@@ -33,7 +33,7 @@ object IngestServiceSpec extends ZIOSpecDefault {
         derivativeExists  <- Files.exists(assetDir / derivativeFilename)
       } yield assertTrue(
         asset.belongsToProject == shortcode,
-        info.originalFilename.toString == fileToIngest.filename.toStrin.toStringg,
+        info.originalFilename.toString == fileToIngest.filename.toString,
         info.originalFilename == asset.original.originalFilename,
         info.asset == asset.ref,
         info.original.checksum == checksum,

--- a/src/test/scala/swiss/dasch/domain/IngestServiceSpec.scala
+++ b/src/test/scala/swiss/dasch/domain/IngestServiceSpec.scala
@@ -1,0 +1,9 @@
+package swiss.dasch.domain
+
+import zio.test.{ZIOSpecDefault, assertCompletes}
+
+object IngestServiceSpec extends ZIOSpecDefault {
+  val spec = suite("IngestServiceSpec")(test("should") {
+    assertCompletes
+  })
+}

--- a/src/test/scala/swiss/dasch/domain/IngestServiceSpec.scala
+++ b/src/test/scala/swiss/dasch/domain/IngestServiceSpec.scala
@@ -13,7 +13,7 @@ import zio.nio.file.Files
 import zio.test.{Spec, ZIOSpecDefault, assertTrue}
 
 object IngestServiceSpec extends ZIOSpecDefault {
-  val spec: Spec[Any, Any] = suite("IngestServiceSpec")(test("should ingest a simple csv file") {
+  val spec: Spec[Any, Any] = suite("IngestService")(test("should ingest a simple csv file") {
     val shortcode = ProjectShortcode.unsafeFrom("0001")
     ZIO.scoped {
       for {

--- a/src/test/scala/swiss/dasch/domain/StorageServiceLiveSpec.scala
+++ b/src/test/scala/swiss/dasch/domain/StorageServiceLiveSpec.scala
@@ -49,12 +49,6 @@ object StorageServiceLiveSpec extends ZIOSpecDefault {
         actual   <- StorageService.getTempDirectory()
       } yield assertTrue(expected == actual)
     },
-    test("should return bulk ingest import folder") {
-      for {
-        expected <- ZIO.serviceWith[StorageConfig](_.tempPath)
-        actual   <- StorageService.getBulkIngestImportFolder(existingProject)
-      } yield assertTrue(actual == expected / "import" / existingProject.value)
-    },
     test("should return project directory") {
       for {
         expected <- ZIO.serviceWith[StorageConfig](_.assetPath).map(_ / existingProject.toString)


### PR DESCRIPTION
Extract code for ingesting a single file to `IngestService` and add a simple test.

Move code for `StorageService` methods `getBulkIngestImportFolder` and `createBulkIngestMappingFile` into the `BulkIngestService`.