### PR TITLE
feat: Add get mapping.csv and finalize endpoints

### DIFF
--- a/src/main/scala/swiss/dasch/api/ProjectsEndpoints.scala
+++ b/src/main/scala/swiss/dasch/api/ProjectsEndpoints.scala
@@ -131,6 +131,17 @@ final case class ProjectsEndpoints(base: BaseEndpoints) {
     )
     .tag(projects)
 
+  val getBulkIngestMappingCsv = base.secureEndpoint.get
+    .in(projects / shortcodePathVar / "bulk-ingest" / "mapping.csv")
+    .description(
+      "Get the current result of the bulk ingest, may be incomplete. " +
+        "The result is a csv with the following structure: " +
+        "original,derivative"
+    )
+    .out(stringBody)
+    .out(header(HeaderNames.ContentType, "text/csv"))
+    .tag(projects)
+
   val postExport = base.secureEndpoint.post
     .in(projects / shortcodePathVar / "export")
     .out(header[String]("Content-Disposition"))
@@ -151,6 +162,7 @@ final case class ProjectsEndpoints(base: BaseEndpoints) {
       getProjectByShortcodeEndpoint,
       getProjectsChecksumReport,
       postBulkIngest,
+      getBulkIngestMappingCsv,
       postExport,
       getImport
     )

--- a/src/main/scala/swiss/dasch/api/ProjectsEndpoints.scala
+++ b/src/main/scala/swiss/dasch/api/ProjectsEndpoints.scala
@@ -131,6 +131,16 @@ final case class ProjectsEndpoints(base: BaseEndpoints) {
     )
     .tag(projects)
 
+  val postBulkIngestFinalize = base.secureEndpoint.post
+    .in(projects / shortcodePathVar / "bulk-ingest" / "finalize")
+    .out(jsonBody[ProjectResponse].example(ProjectResponse("0001")))
+    .description(
+      "Finalizes the bulk ingest. " +
+        "This will remove the files from the `tmp/<project_shortcode>` directory and the directory itself. " +
+        "This will remove also the mapping.csv file."
+    )
+    .tag(projects)
+
   val getBulkIngestMappingCsv = base.secureEndpoint.get
     .in(projects / shortcodePathVar / "bulk-ingest" / "mapping.csv")
     .description(

--- a/src/main/scala/swiss/dasch/api/ProjectsEndpointsHandler.scala
+++ b/src/main/scala/swiss/dasch/api/ProjectsEndpointsHandler.scala
@@ -64,6 +64,19 @@ final case class ProjectsEndpointsHandler(
       code => bulkIngestService.startBulkIngest(code).logError.forkDaemon.as(ProjectResponse.make(code))
     )
 
+  val getBulkIngestMappingCsvEndpoint: ZServerEndpoint[Any, Any] =
+    projectEndpoints.getBulkIngestMappingCsv
+      .serverLogic(_ =>
+        code =>
+          bulkIngestService
+            .getBulkIngestMappingCsv(code)
+            .some
+            .mapBoth(
+              projectNotFoundOrServerError(_, code),
+              str => str
+            )
+      )
+
   val postExportEndpoint: ZServerEndpoint[Any, ZioStreams] = projectEndpoints.postExport
     .serverLogic(_ =>
       shortcode =>
@@ -103,6 +116,7 @@ final case class ProjectsEndpointsHandler(
       getProjectByShortcodeEndpoint,
       getProjectChecksumReportEndpoint,
       postBulkIngestEndpoint,
+      getBulkIngestMappingCsvEndpoint,
       postExportEndpoint,
       getImportEndpoint
     )

--- a/src/main/scala/swiss/dasch/api/ProjectsEndpointsHandler.scala
+++ b/src/main/scala/swiss/dasch/api/ProjectsEndpointsHandler.scala
@@ -64,6 +64,11 @@ final case class ProjectsEndpointsHandler(
       code => bulkIngestService.startBulkIngest(code).logError.forkDaemon.as(ProjectResponse.make(code))
     )
 
+  val postBulkIngestEndpointFinalize: ZServerEndpoint[Any, Any] = projectEndpoints.postBulkIngestFinalize
+    .serverLogic(_ =>
+      code => bulkIngestService.finalizeBulkIngest(code).logError.forkDaemon.as(ProjectResponse.make(code))
+    )
+
   val getBulkIngestMappingCsvEndpoint: ZServerEndpoint[Any, Any] =
     projectEndpoints.getBulkIngestMappingCsv
       .serverLogic(_ =>
@@ -116,6 +121,7 @@ final case class ProjectsEndpointsHandler(
       getProjectByShortcodeEndpoint,
       getProjectChecksumReportEndpoint,
       postBulkIngestEndpoint,
+      postBulkIngestEndpointFinalize,
       getBulkIngestMappingCsvEndpoint,
       postExportEndpoint,
       getImportEndpoint

--- a/src/main/scala/swiss/dasch/domain/BulkIngestService.scala
+++ b/src/main/scala/swiss/dasch/domain/BulkIngestService.scala
@@ -26,6 +26,9 @@ object BulkIngestService {
 
   def finalizeBulkIngest(shortcode: ProjectShortcode): ZIO[BulkIngestService, Throwable, Unit] =
     ZIO.serviceWithZIO[BulkIngestService](_.finalizeBulkIngest(shortcode))
+
+  def getBulkIngestMappingCsv(shortcode: ProjectShortcode): ZIO[BulkIngestService, Throwable, Option[String]] =
+    ZIO.serviceWithZIO[BulkIngestService](_.getBulkIngestMappingCsv(shortcode))
 }
 
 case class IngestResult(success: Int = 0, failed: Int = 0) {

--- a/src/main/scala/swiss/dasch/domain/BulkIngestService.scala
+++ b/src/main/scala/swiss/dasch/domain/BulkIngestService.scala
@@ -102,7 +102,7 @@ final case class BulkIngestServiceLive(
     _         <- ZIO.logInfo(s"Finalizing bulk ingest for project $shortcode")
     importDir <- getImportFolder(shortcode)
     mappingCsv = getMappingCsvFile(importDir, shortcode)
-    _         <- Files.deleteRecursive(importDir)
+    _         <- storage.deleteRecursive(importDir)
     _         <- storage.delete(mappingCsv)
     _         <- ZIO.logInfo(s"Finished finalizing bulk ingest for project $shortcode")
   } yield ()

--- a/src/main/scala/swiss/dasch/domain/BulkIngestService.scala
+++ b/src/main/scala/swiss/dasch/domain/BulkIngestService.scala
@@ -23,6 +23,9 @@ trait BulkIngestService {
 object BulkIngestService {
   def startBulkIngest(shortcode: ProjectShortcode): ZIO[BulkIngestService, Throwable, IngestResult] =
     ZIO.serviceWithZIO[BulkIngestService](_.startBulkIngest(shortcode))
+
+  def finalizeBulkIngest(shortcode: ProjectShortcode): ZIO[BulkIngestService, Throwable, Unit] =
+    ZIO.serviceWithZIO[BulkIngestService](_.finalizeBulkIngest(shortcode))
 }
 
 case class IngestResult(success: Int = 0, failed: Int = 0) {

--- a/src/main/scala/swiss/dasch/domain/StorageService.scala
+++ b/src/main/scala/swiss/dasch/domain/StorageService.scala
@@ -31,6 +31,7 @@ trait StorageService {
   def copyFile(source: Path, target: Path, copyOption: CopyOption*): IO[IOException, Unit]
   def createDirectories(path: Path, attrs: FileAttribute[_]*): IO[IOException, Unit]
   def delete(path: Path): IO[IOException, Unit]
+  def deleteRecursive(path: Path): IO[IOException, Long]
 }
 
 object StorageService {
@@ -117,6 +118,9 @@ final case class StorageServiceLive(config: StorageConfig) extends StorageServic
 
   override def delete(path: Path): IO[IOException, Unit] =
     Files.delete(path)
+
+  override def deleteRecursive(path: Path): IO[IOException, Long] =
+    Files.deleteRecursive(path)
 }
 object StorageServiceLive {
   val layer: URLayer[StorageConfig, StorageService] = ZLayer.derive[StorageServiceLive]

--- a/src/test/scala/swiss/dasch/domain/BulkIngestServiceLiveSpec.scala
+++ b/src/test/scala/swiss/dasch/domain/BulkIngestServiceLiveSpec.scala
@@ -1,0 +1,40 @@
+package swiss.dasch.domain
+
+import swiss.dasch.api.SipiClientMock
+import swiss.dasch.test.SpecConfigurations
+import zio.nio.file.Files
+import zio.test.{ZIOSpecDefault, assertTrue}
+
+object BulkIngestServiceLiveSpec extends ZIOSpecDefault {
+
+  private val finalizeBulkIngestSuite = suite("finalize bulk ingest should")(test("remove all files") {
+    val shortcode = ProjectShortcode.unsafeFrom("0001")
+    for {
+      // given
+      importDir <- StorageService
+                     .getTempDirectory()
+                     .map(_ / "import" / shortcode.value)
+                     .tap(Files.createDirectories(_))
+      _ <- Files.createFile(importDir / "0001.tif")
+      _ <- Files.createFile(importDir.parent.head / s"mapping-$shortcode.csv")
+      // when
+      _ <- BulkIngestService.finalizeBulkIngest(shortcode)
+      // then
+      importDirDeleted   <- Files.exists(importDir).negate
+      mappingFileDeleted <- Files.exists(importDir.parent.head / s"mapping-$shortcode.csv").negate
+    } yield assertTrue(importDirDeleted && mappingFileDeleted)
+  })
+
+  val spec = suite("BulkIngestServiceLive")(
+    finalizeBulkIngestSuite
+  ).provide(
+    AssetInfoServiceLive.layer,
+    BulkIngestServiceLive.layer,
+    ImageServiceLive.layer,
+    IngestService.layer,
+    SipiClientMock.layer,
+    SpecConfigurations.ingestConfigLayer,
+    SpecConfigurations.storageConfigLayer,
+    StorageServiceLive.layer
+  )
+}

--- a/src/test/scala/swiss/dasch/domain/BulkIngestServiceLiveSpec.scala
+++ b/src/test/scala/swiss/dasch/domain/BulkIngestServiceLiveSpec.scala
@@ -15,13 +15,14 @@ object BulkIngestServiceLiveSpec extends ZIOSpecDefault {
                      .getTempDirectory()
                      .map(_ / "import" / shortcode.value)
                      .tap(Files.createDirectories(_))
-      _ <- Files.createFile(importDir / "0001.tif")
-      _ <- Files.createFile(importDir.parent.head / s"mapping-$shortcode.csv")
+      _             <- Files.createFile(importDir / "0001.tif")
+      mappingCsvFile = importDir.parent.head / s"mapping-$shortcode.csv"
+      _             <- Files.createFile(mappingCsvFile)
       // when
       _ <- BulkIngestService.finalizeBulkIngest(shortcode)
       // then
       importDirDeleted   <- Files.exists(importDir).negate
-      mappingFileDeleted <- Files.exists(importDir.parent.head / s"mapping-$shortcode.csv").negate
+      mappingFileDeleted <- Files.exists(mappingCsvFile).negate
     } yield assertTrue(importDirDeleted && mappingFileDeleted)
   })
 

--- a/src/test/scala/swiss/dasch/domain/BulkIngestServiceLiveSpec.scala
+++ b/src/test/scala/swiss/dasch/domain/BulkIngestServiceLiveSpec.scala
@@ -1,3 +1,8 @@
+/*
+ * Copyright © 2021 - 2023 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package swiss.dasch.domain
 
 import swiss.dasch.api.SipiClientMock


### PR DESCRIPTION
`GET /projects/<shortcode>/bulk-ingest/mapping.csv` endpoint

Returns the current state of the mapping csv. May be incomplete if a bulk-ingest is still in progress.


`POST /projects/<shortcode>/bulk-ingest/finalize` endpoint

Removes the `/tmp/<shortcode>` and `/tmp/mapping-<shortcode>.csv` files and folders.