### PR TITLE
feat: Add asset info endpoint and image meta data extraction

### DIFF
--- a/src/main/scala/swiss/dasch/api/HandlerFunctions.scala
+++ b/src/main/scala/swiss/dasch/api/HandlerFunctions.scala
@@ -6,10 +6,15 @@
 package swiss.dasch.api
 
 import swiss.dasch.api.ApiProblem.{InternalServerError, NotFound}
-import swiss.dasch.domain.ProjectShortcode
+import swiss.dasch.domain.{AssetRef, ProjectShortcode}
 
 trait HandlerFunctions {
 
   def projectNotFoundOrServerError(mayBeError: Option[Throwable], shortcode: ProjectShortcode): ApiProblem =
     mayBeError.map(InternalServerError(_)).getOrElse(NotFound(shortcode))
+
+  def assetRefNotFoundOrServerError(mayBeError: Option[Throwable], assetRef: AssetRef): ApiProblem =
+    mayBeError
+      .map(InternalServerError(_))
+      .getOrElse(NotFound(s"${assetRef.belongsToProject}/${assetRef.id}", "AssetRef"))
 }

--- a/src/main/scala/swiss/dasch/api/ProjectsEndpoints.scala
+++ b/src/main/scala/swiss/dasch/api/ProjectsEndpoints.scala
@@ -158,7 +158,7 @@ final case class ProjectsEndpoints(base: BaseEndpoints) {
   val getProjectsAssetsInfo = base.secureEndpoint.get
     .in(projects / shortcodePathVar / "assets" / path[AssetId]("assetId"))
     .out(jsonBody[AssetInfoResponse])
-    .tag(projects)
+    .tag(projects ++ "assets")
 
   val postBulkIngest = base.secureEndpoint.post
     .in(projects / shortcodePathVar / "bulk-ingest")

--- a/src/main/scala/swiss/dasch/api/ProjectsEndpoints.scala
+++ b/src/main/scala/swiss/dasch/api/ProjectsEndpoints.scala
@@ -55,7 +55,7 @@ object ProjectsEndpointsResponses {
 
     def make(assetInfo: AssetInfo, results: Chunk[ChecksumResult]): AssetCheckResultEntry =
       AssetCheckResultEntry(
-        assetInfo.assetRef.id.toString,
+        assetInfo.assetRef.id.value,
         assetInfo.originalFilename.toString,
         results.map(SingleFileCheckResultResponse.make).toList
       )

--- a/src/main/scala/swiss/dasch/api/ProjectsEndpoints.scala
+++ b/src/main/scala/swiss/dasch/api/ProjectsEndpoints.scala
@@ -116,10 +116,10 @@ object ProjectsEndpointsResponses {
         assetInfo.originalFilename.toString,
         assetInfo.original.checksum.toString,
         assetInfo.derivative.checksum.toString,
-        assetInfo.movingImageMetadata.map(_.width),
-        assetInfo.movingImageMetadata.map(_.height),
-        assetInfo.movingImageMetadata.map(_.duration),
-        assetInfo.movingImageMetadata.map(_.fps)
+        assetInfo.metadata.map(_.dimensions.width.value),
+        assetInfo.metadata.map(_.dimensions.height.value),
+        assetInfo.metadata.map(_.duration),
+        assetInfo.metadata.map(_.fps)
       )
 
     given codec: JsonCodec[AssetInfoResponse] = DeriveJsonCodec.gen[AssetInfoResponse]

--- a/src/main/scala/swiss/dasch/api/ProjectsEndpoints.scala
+++ b/src/main/scala/swiss/dasch/api/ProjectsEndpoints.scala
@@ -109,18 +109,28 @@ object ProjectsEndpointsResponses {
   )
   object AssetInfoResponse {
 
-    def from(assetInfo: AssetInfo): AssetInfoResponse =
+    def from(assetInfo: AssetInfo): AssetInfoResponse = {
+      val dim = assetInfo.metadata match {
+        case MovingImageMetadata(d, _, _) => Some(d)
+        case d: Dimensions                => Some(d)
+        case _                            => None
+      }
+      val movingImageMeta = assetInfo.metadata match {
+        case m: MovingImageMetadata => Some(m)
+        case _                      => None
+      }
       AssetInfoResponse(
         assetInfo.derivative.filename.toString,
         assetInfo.original.filename.toString,
         assetInfo.originalFilename.toString,
         assetInfo.original.checksum.toString,
         assetInfo.derivative.checksum.toString,
-        assetInfo.metadata.map(_.dimensions.width.value),
-        assetInfo.metadata.map(_.dimensions.height.value),
-        assetInfo.metadata.map(_.duration),
-        assetInfo.metadata.map(_.fps)
+        dim.map(_.width.value),
+        dim.map(_.height.value),
+        movingImageMeta.map(_.duration),
+        movingImageMeta.map(_.fps)
       )
+    }
 
     given codec: JsonCodec[AssetInfoResponse] = DeriveJsonCodec.gen[AssetInfoResponse]
     given schema: Schema[AssetInfoResponse]   = DeriveSchema.gen[AssetInfoResponse]

--- a/src/main/scala/swiss/dasch/api/ProjectsEndpointsHandler.scala
+++ b/src/main/scala/swiss/dasch/api/ProjectsEndpointsHandler.scala
@@ -53,7 +53,7 @@ final case class ProjectsEndpointsHandler(
           )
     )
 
-  val getProjectChecksumReportEndpoint: ZServerEndpoint[Any, Any] = projectEndpoints.getProjectsChecksumReport
+  private val getProjectChecksumReportEndpoint: ZServerEndpoint[Any, Any] = projectEndpoints.getProjectsChecksumReport
     .serverLogic(_ =>
       shortcode =>
         reportService
@@ -65,7 +65,7 @@ final case class ProjectsEndpointsHandler(
           )
     )
 
-  val getProjectsAssetsInfoEndpoint: ZServerEndpoint[Any, Any] = projectEndpoints.getProjectsAssetsInfo
+  private val getProjectsAssetsInfoEndpoint: ZServerEndpoint[Any, Any] = projectEndpoints.getProjectsAssetsInfo
     .serverLogic(_ =>
       (shortcode, assetId) => {
         val ref = AssetRef(assetId, shortcode)
@@ -79,17 +79,17 @@ final case class ProjectsEndpointsHandler(
       }
     )
 
-  val postBulkIngestEndpoint: ZServerEndpoint[Any, Any] = projectEndpoints.postBulkIngest
+  private val postBulkIngestEndpoint: ZServerEndpoint[Any, Any] = projectEndpoints.postBulkIngest
     .serverLogic(_ =>
       code => bulkIngestService.startBulkIngest(code).logError.forkDaemon.as(ProjectResponse.make(code))
     )
 
-  val postBulkIngestEndpointFinalize: ZServerEndpoint[Any, Any] = projectEndpoints.postBulkIngestFinalize
+  private val postBulkIngestEndpointFinalize: ZServerEndpoint[Any, Any] = projectEndpoints.postBulkIngestFinalize
     .serverLogic(_ =>
       code => bulkIngestService.finalizeBulkIngest(code).logError.forkDaemon.as(ProjectResponse.make(code))
     )
 
-  val getBulkIngestMappingCsvEndpoint: ZServerEndpoint[Any, Any] =
+  private val getBulkIngestMappingCsvEndpoint: ZServerEndpoint[Any, Any] =
     projectEndpoints.getBulkIngestMappingCsv
       .serverLogic(_ =>
         code =>
@@ -102,7 +102,7 @@ final case class ProjectsEndpointsHandler(
             )
       )
 
-  val postExportEndpoint: ZServerEndpoint[Any, ZioStreams] = projectEndpoints.postExport
+  private val postExportEndpoint: ZServerEndpoint[Any, ZioStreams] = projectEndpoints.postExport
     .serverLogic(_ =>
       shortcode =>
         projectService
@@ -119,7 +119,7 @@ final case class ProjectsEndpointsHandler(
           )
     )
 
-  val getImportEndpoint: ZServerEndpoint[Any, ZioStreams] = projectEndpoints.getImport
+  private val getImportEndpoint: ZServerEndpoint[Any, ZioStreams] = projectEndpoints.getImport
     .serverLogic(_ =>
       (shortcode, stream) =>
         importService

--- a/src/main/scala/swiss/dasch/api/ProjectsEndpointsHandler.scala
+++ b/src/main/scala/swiss/dasch/api/ProjectsEndpointsHandler.scala
@@ -67,16 +67,17 @@ final case class ProjectsEndpointsHandler(
 
   val getProjectsAssetsInfoEndpoint: ZServerEndpoint[Any, Any] = projectEndpoints.getProjectsAssetsInfo
     .serverLogic(_ =>
-      (shortcode, assetId) => {
-        val ref = AssetRef(assetId, shortcode)
-        assetInfoService
-          .findByAssetRef(ref)
-          .some
-          .mapBoth(
-            assetRefNotFoundOrServerError(_, ref),
-            AssetInfoResponse.from
-          )
-      }jin
+      (shortcode, assetId) =>
+        {
+          val ref = AssetRef(assetId, shortcode)
+          assetInfoService
+            .findByAssetRef(ref)
+            .some
+            .mapBoth(
+              assetRefNotFoundOrServerError(_, ref),
+              AssetInfoResponse.from
+            )
+        }
     )
 
   val postBulkIngestEndpoint: ZServerEndpoint[Any, Any] = projectEndpoints.postBulkIngest

--- a/src/main/scala/swiss/dasch/api/ProjectsEndpointsHandler.scala
+++ b/src/main/scala/swiss/dasch/api/ProjectsEndpointsHandler.scala
@@ -67,17 +67,16 @@ final case class ProjectsEndpointsHandler(
 
   val getProjectsAssetsInfoEndpoint: ZServerEndpoint[Any, Any] = projectEndpoints.getProjectsAssetsInfo
     .serverLogic(_ =>
-      (shortcode, assetId) =>
-        {
-          val ref = AssetRef(assetId, shortcode)
-          assetInfoService
-            .findByAssetRef(ref)
-            .some
-            .mapBoth(
-              assetRefNotFoundOrServerError(_, ref),
-              AssetInfoResponse.from
-            )
-        }
+      (shortcode, assetId) => {
+        val ref = AssetRef(assetId, shortcode)
+        assetInfoService
+          .findByAssetRef(ref)
+          .some
+          .mapBoth(
+            assetRefNotFoundOrServerError(_, ref),
+            AssetInfoResponse.from
+          )
+      }
     )
 
   val postBulkIngestEndpoint: ZServerEndpoint[Any, Any] = projectEndpoints.postBulkIngest

--- a/src/main/scala/swiss/dasch/domain/AssetInfoService.scala
+++ b/src/main/scala/swiss/dasch/domain/AssetInfoService.scala
@@ -33,9 +33,9 @@ private object AssetInfoFileContent {
     metadata: AssetMetadata
   ): AssetInfoFileContent = {
     val dim = metadata match {
-      case MovingImageMetadata(dim, _, _) => Some(dim)
-      case d: Dimensions                  => Some(d)
-      case _                              => None
+      case MovingImageMetadata(d, _, _) => Some(d)
+      case d: Dimensions                => Some(d)
+      case _                            => None
     }
     val duration = metadata match {
       case MovingImageMetadata(_, duration, _) => Some(duration)

--- a/src/main/scala/swiss/dasch/domain/AssetInfoService.scala
+++ b/src/main/scala/swiss/dasch/domain/AssetInfoService.scala
@@ -85,7 +85,7 @@ final case class AssetInfoServiceLive(storage: StorageService) extends AssetInfo
   override def loadFromFilesystem(infoFile: Path, shortcode: ProjectShortcode): Task[AssetInfo] =
     for {
       content   <- storage.loadJsonFile[AssetInfoFileContent](infoFile)
-      assetMaybe = AssetId.makeFromPath(Path(content.internalFilename.toString)).map(id => AssetRef(id, shortcode))
+      assetMaybe = AssetId.fromPath(Path(content.internalFilename.toString)).map(id => AssetRef(id, shortcode))
       assetInfo <- assetMaybe match {
                      case Some(asset) => ZIO.succeed(toAssetInfo(content, infoFile.parent.orNull, asset))
                      case None        => ZIO.fail(IllegalArgumentException(s"Unable to parse asset id from $infoFile"))
@@ -134,7 +134,7 @@ final case class AssetInfoServiceLive(storage: StorageService) extends AssetInfo
 
   override def updateAssetInfoForDerivative(derivative: Path): Task[Unit] = for {
     assetId <- ZIO
-                 .fromOption(AssetId.makeFromPath(derivative))
+                 .fromOption(AssetId.fromPath(derivative))
                  .orElseFail(IllegalArgumentException(s"Unable to parse asset id from $derivative"))
     infoFile = derivative.parent.map(_ / infoFilename(assetId)).orNull
     _       <- ZIO.whenZIO(Files.exists(infoFile))(updateDerivativeChecksum(infoFile, derivative))

--- a/src/main/scala/swiss/dasch/domain/AssetMetadata.scala
+++ b/src/main/scala/swiss/dasch/domain/AssetMetadata.scala
@@ -1,0 +1,26 @@
+package swiss.dasch.domain
+
+import eu.timepit.refined.api.Refined
+import eu.timepit.refined.numeric.Positive
+import eu.timepit.refined.refineV
+import zio.json.interop.refined.{decodeRefined, encodeRefined}
+import zio.json.{DeriveJsonCodec, JsonCodec}
+
+sealed trait AssetMetadata
+
+final case class Dimensions(width: Int Refined Positive, height: Int Refined Positive) extends AssetMetadata
+object Dimensions {
+  given codec: JsonCodec[Dimensions] = DeriveJsonCodec.gen[Dimensions]
+
+  def unsafeFrom(width: Int, height: Int): Dimensions =
+    Dimensions.from(width, height).fold(msg => throw new IllegalArgumentException(msg), identity)
+  def from(width: Int, height: Int): Either[String, Dimensions] =
+    for {
+      w <- refineV[Positive](width)
+      h <- refineV[Positive](height)
+    } yield Dimensions(w, h)
+}
+
+final case class MovingImageMetadata(dimensions: Dimensions, duration: Double, fps: Double) extends AssetMetadata
+
+case object EmptyMetadata extends AssetMetadata

--- a/src/main/scala/swiss/dasch/domain/AssetMetadata.scala
+++ b/src/main/scala/swiss/dasch/domain/AssetMetadata.scala
@@ -1,3 +1,8 @@
+/*
+ * Copyright © 2021 - 2023 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package swiss.dasch.domain
 
 import eu.timepit.refined.api.Refined

--- a/src/main/scala/swiss/dasch/domain/AssetModel.scala
+++ b/src/main/scala/swiss/dasch/domain/AssetModel.scala
@@ -18,7 +18,7 @@ import zio.json.JsonCodec
 import zio.nio.file.Path
 import zio.{Random, UIO}
 
-opaque type AssetId = String Refined MatchesRegex["^[a-zA-Z0-9-_]{4,}$"]
+type AssetId = String Refined MatchesRegex["^[a-zA-Z0-9-_]{4,}$"]
 
 object AssetId {
   def make(id: String): Either[String, AssetId] = refineV(id)

--- a/src/main/scala/swiss/dasch/domain/AssetModel.scala
+++ b/src/main/scala/swiss/dasch/domain/AssetModel.scala
@@ -27,7 +27,7 @@ object AssetId extends RefinedTypeOps[AssetId, String] {
       AssetId.unsafeFrom(Base62.encode(uuid).value)
     )
 
-  def romPath(file: Path): Option[AssetId] = {
+  def fromPath(file: Path): Option[AssetId] = {
     val filename = file.filename.toString
 
     if (filename.contains(".")) AssetId.from(filename.substring(0, filename.indexOf("."))).toOption

--- a/src/main/scala/swiss/dasch/domain/AssetModel.scala
+++ b/src/main/scala/swiss/dasch/domain/AssetModel.scala
@@ -56,7 +56,13 @@ sealed trait Asset {
 }
 
 object Asset {
-  final case class StillImageAsset(ref: AssetRef, original: Original, derivative: JpxDerivativeFile) extends Asset
+  final case class StillImageAsset(
+    ref: AssetRef,
+    original: Original,
+    derivative: JpxDerivativeFile,
+    metadata: Dimensions
+  ) extends Asset
+
   final case class MovingImageAsset(
     ref: AssetRef,
     original: Original,
@@ -65,8 +71,14 @@ object Asset {
   ) extends Asset
   final case class OtherAsset(ref: AssetRef, original: Original, derivative: DerivativeFile) extends Asset
 
-  def makeStillImage(assetRef: AssetRef, original: Original, derivative: JpxDerivativeFile): StillImageAsset =
-    StillImageAsset(assetRef, original, derivative)
+  def makeStillImage(
+    assetRef: AssetRef,
+    original: Original,
+    derivative: JpxDerivativeFile,
+    metadata: Dimensions
+  ): StillImageAsset =
+    StillImageAsset(assetRef, original, derivative, metadata)
+
   def makeMovingImageAsset(
     assetRef: AssetRef,
     original: Original,

--- a/src/main/scala/swiss/dasch/domain/AssetModel.scala
+++ b/src/main/scala/swiss/dasch/domain/AssetModel.scala
@@ -51,6 +51,7 @@ sealed trait Asset {
   def ref: AssetRef
   def original: Original
   def derivative: DerivativeFile
+  def metadata: AssetMetadata
   final def id: AssetId                        = ref.id
   final def belongsToProject: ProjectShortcode = ref.belongsToProject
 }
@@ -69,7 +70,12 @@ object Asset {
     derivative: DerivativeFile,
     metadata: MovingImageMetadata
   ) extends Asset
-  final case class OtherAsset(ref: AssetRef, original: Original, derivative: DerivativeFile) extends Asset
+
+  final case class OtherAsset(
+    ref: AssetRef,
+    original: Original,
+    derivative: DerivativeFile
+  ) extends Asset { override val metadata: AssetMetadata = EmptyMetadata }
 
   def makeStillImage(
     assetRef: AssetRef,

--- a/src/main/scala/swiss/dasch/domain/FileChecksumService.scala
+++ b/src/main/scala/swiss/dasch/domain/FileChecksumService.scala
@@ -55,7 +55,11 @@ final case class FileChecksumServiceLive(assetInfos: AssetInfoService) extends F
     verifyChecksum(asset, _.derivative)
 
   private def verifyChecksum(assetRef: AssetRef, checksumAndFile: AssetInfo => FileAndChecksum): Task[Boolean] =
-    assetInfos.findByAssetRef(assetRef).map(checksumAndFile).flatMap(verifyChecksum)
+    assetInfos
+      .findByAssetRef(assetRef)
+      .someOrFail(new NoSuchElementException(s"Asset $assetRef not found."))
+      .map(checksumAndFile)
+      .flatMap(verifyChecksum)
 
   private def verifyChecksum(fileAndChecksum: FileAndChecksum): Task[Boolean] =
     FileChecksumService

--- a/src/main/scala/swiss/dasch/domain/IngestService.scala
+++ b/src/main/scala/swiss/dasch/domain/IngestService.scala
@@ -5,6 +5,7 @@
 
 package swiss.dasch.domain
 
+import eu.timepit.refined.api.Refined
 import eu.timepit.refined.types.string.NonEmptyString
 import org.apache.commons.io.FilenameUtils
 import swiss.dasch.domain.Asset.{MovingImageAsset, OtherAsset, StillImageAsset}
@@ -62,10 +63,12 @@ final case class IngestService(
     }
 
   private def handleImageFile(original: Original, assetRef: AssetRef): Task[StillImageAsset] =
-    ZIO.logInfo(s"Creating derivative for image $original, $assetRef") *>
-      stillImageService
-        .createDerivative(original.file)
-        .map(derivative => Asset.makeStillImage(assetRef, original, derivative))
+    ZIO.logInfo(s"Creating derivative for image $original, $assetRef") *> {
+      for {
+        derivative <- stillImageService.createDerivative(original.file)
+        dim        <- stillImageService.getDimensions(derivative)
+      } yield Asset.makeStillImage(assetRef, original, derivative, dim)
+    }
 
   private def handleOtherFile(original: Original, assetRef: AssetRef, assetDir: Path): Task[OtherAsset] =
     ZIO.logInfo(s"Creating derivative for other $original, $assetRef") *> {

--- a/src/main/scala/swiss/dasch/domain/IngestService.scala
+++ b/src/main/scala/swiss/dasch/domain/IngestService.scala
@@ -88,7 +88,7 @@ final case class IngestService(
     // remove all files and folders which start with the asset id and remove empty assetDir
     ZIO.logInfo(s"Failed ingest for $assetRef cleaning up in directory $assetDir") *>
       StorageService
-        .findInPath(assetDir, p => ZIO.succeed(p.filename.toString.startsWith(assetRef.id.toString)), maxDepth = 1)
+        .findInPath(assetDir, p => ZIO.succeed(p.filename.toString.startsWith(assetRef.id.value)), maxDepth = 1)
         .mapZIO(p => ZIO.ifZIO(Files.isDirectory(p))(storage.deleteRecursive(p).unit, storage.delete(p)))
         .runDrain *> storage.deleteDirectoryIfEmpty(assetDir) *> storage.deleteDirectoryIfEmpty(assetDir.parent.head)
 }

--- a/src/main/scala/swiss/dasch/domain/MaintenanceActions.scala
+++ b/src/main/scala/swiss/dasch/domain/MaintenanceActions.scala
@@ -70,7 +70,7 @@ final case class MaintenanceActionsLive(
   }
 
   private def originalNotPresent(imagesOnly: Boolean)(path: file.Path): IO[IOException, Boolean] = {
-    lazy val assetId = AssetId.makeFromPath(path).map(_.toString).getOrElse("unknown-asset-id")
+    lazy val assetId = AssetId.fromPath(path).map(_.toString).getOrElse("unknown-asset-id")
 
     def checkIsImageIfNeeded(path: file.Path) = {
       val shouldNotCheckImages = ZIO.succeed(!imagesOnly)
@@ -162,7 +162,7 @@ final case class MaintenanceActionsLive(
       // must be a .bak file
       bakFile <- ZIO.succeed(path).whenZIO(FileFilters.isBakFile(path)).some
       // must have an AssetId
-      assetId <- ZIO.fromOption(AssetId.makeFromPath(bakFile))
+      assetId <- ZIO.fromOption(AssetId.fromPath(bakFile))
       // must have a corresponding Jpeg2000 derivative
       bakFilename        = bakFile.filename.toString
       derivativeFilename = bakFilename.substring(0, bakFilename.length - ".bak".length)
@@ -211,7 +211,7 @@ final case class MaintenanceActionsLive(
     jpxPath: Path,
     mapping: Map[String, String]
   ): ZStream[Any, Throwable, CreateOriginalFor] =
-    AssetId.makeFromPath(jpxPath) match {
+    AssetId.fromPath(jpxPath) match {
       case Some(assetId) => filterWithoutOriginal(assetId, jpxPath, mapping)
       case None          => ZStream.logWarning(s"Not an assetId: $jpxPath") *> ZStream.empty
     }

--- a/src/main/scala/swiss/dasch/domain/MovingImageService.scala
+++ b/src/main/scala/swiss/dasch/domain/MovingImageService.scala
@@ -12,8 +12,6 @@ import zio.json.{DecoderOps, DeriveJsonDecoder, JsonDecoder}
 import zio.nio.file.Path
 import zio.{Task, ZIO, ZLayer}
 
-final case class MovingImageMetadata(dimensions: Dimensions, duration: Double, fps: Double)
-
 case class MovingImageService(storage: StorageService, executor: CommandExecutor) {
 
   def createDerivative(original: Original, assetRef: AssetRef): Task[MovingImageDerivativeFile] =

--- a/src/main/scala/swiss/dasch/domain/MovingImageService.scala
+++ b/src/main/scala/swiss/dasch/domain/MovingImageService.scala
@@ -12,7 +12,7 @@ import zio.json.{DecoderOps, DeriveJsonDecoder, JsonDecoder}
 import zio.nio.file.Path
 import zio.{Task, ZIO, ZLayer}
 
-final case class MovingImageMetadata(width: Int, height: Int, duration: Double, fps: Double)
+final case class MovingImageMetadata(dimensions: Dimensions, duration: Double, fps: Double)
 
 case class MovingImageService(storage: StorageService, executor: CommandExecutor) {
 
@@ -75,7 +75,8 @@ case class MovingImageService(storage: StorageService, executor: CommandExecutor
             numerator   <- fpsFraction(0).trim.toDoubleOption
             denominator <- fpsFraction(1).trim.toDoubleOption.filter(_ != 0)
             fps          = numerator / denominator
-          } yield MovingImageMetadata(stream.width, stream.height, stream.duration, fps)
+            dim         <- Dimensions.from(stream.width, stream.height).toOption
+          } yield MovingImageMetadata(dim, stream.duration, fps)
         } else { None }
       }
   }

--- a/src/main/scala/swiss/dasch/domain/StillImageService.scala
+++ b/src/main/scala/swiss/dasch/domain/StillImageService.scala
@@ -8,19 +8,26 @@ package swiss.dasch.domain
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.numeric.Positive
 import eu.timepit.refined.refineV
+import swiss.dasch.domain.DerivativeFile.JpxDerivativeFile
 import swiss.dasch.domain.SipiImageFormat.Jpx
 import zio.*
+import zio.json.interop.refined.*
 import zio.json.{DeriveJsonCodec, JsonCodec}
 import zio.nio.file.{Files, Path}
-import zio.json.interop.refined.*
-
-import DerivativeFile.JpxDerivativeFile
 
 import java.io.IOException
 
 final case class Dimensions(width: Int Refined Positive, height: Int Refined Positive)
 object Dimensions {
   given codec: JsonCodec[Dimensions] = DeriveJsonCodec.gen[Dimensions]
+
+  def unsafeFrom(width: Int, height: Int): Dimensions =
+    Dimensions.from(width, height).fold(msg => throw new IllegalArgumentException(msg), identity)
+  def from(width: Int, height: Int): Either[String, Dimensions] =
+    for {
+      w <- refineV[Positive](width)
+      h <- refineV[Positive](height)
+    } yield Dimensions(w, h)
 }
 
 trait StillImageService {

--- a/src/main/scala/swiss/dasch/domain/StillImageService.scala
+++ b/src/main/scala/swiss/dasch/domain/StillImageService.scala
@@ -11,24 +11,9 @@ import eu.timepit.refined.refineV
 import swiss.dasch.domain.DerivativeFile.JpxDerivativeFile
 import swiss.dasch.domain.SipiImageFormat.Jpx
 import zio.*
-import zio.json.interop.refined.*
-import zio.json.{DeriveJsonCodec, JsonCodec}
 import zio.nio.file.{Files, Path}
 
 import java.io.IOException
-
-final case class Dimensions(width: Int Refined Positive, height: Int Refined Positive)
-object Dimensions {
-  given codec: JsonCodec[Dimensions] = DeriveJsonCodec.gen[Dimensions]
-
-  def unsafeFrom(width: Int, height: Int): Dimensions =
-    Dimensions.from(width, height).fold(msg => throw new IllegalArgumentException(msg), identity)
-  def from(width: Int, height: Int): Either[String, Dimensions] =
-    for {
-      w <- refineV[Positive](width)
-      h <- refineV[Positive](height)
-    } yield Dimensions(w, h)
-}
 
 trait StillImageService {
 

--- a/src/main/scala/swiss/dasch/domain/StorageService.scala
+++ b/src/main/scala/swiss/dasch/domain/StorageService.scala
@@ -25,6 +25,7 @@ trait StorageService {
   def getAssetDirectory(asset: AssetRef): UIO[Path]
   def getAssetDirectory(): UIO[Path]
   def getTempDirectory(): UIO[Path]
+  def fileExists(path: Path): IO[IOException, Boolean]
   def createTempDirectoryScoped(directoryName: String, prefix: Option[String] = None): ZIO[Scope, IOException, Path]
   def loadJsonFile[A](file: Path)(implicit decoder: JsonDecoder[A]): Task[A]
   def saveJsonFile[A](file: Path, content: A)(implicit encoder: JsonEncoder[A]): Task[Unit]
@@ -81,6 +82,9 @@ final case class StorageServiceLive(config: StorageConfig) extends StorageServic
 
   override def getTempDirectory(): UIO[Path] =
     ZIO.succeed(config.tempPath)
+
+  override def fileExists(path: Path): IO[IOException, Boolean] =
+    Files.exists(path)
 
   override def getAssetDirectory(): UIO[Path] =
     ZIO.succeed(config.assetPath)

--- a/src/main/scala/swiss/dasch/domain/StorageService.scala
+++ b/src/main/scala/swiss/dasch/domain/StorageService.scala
@@ -96,7 +96,7 @@ final case class StorageServiceLive(config: StorageConfig) extends StorageServic
     getProjectDirectory(asset.belongsToProject).map(_ / segments(asset.id))
 
   private def segments(assetId: AssetId): Path = {
-    val assetString = assetId.toString
+    val assetString = assetId.value
     val segment1    = assetString.substring(0, 2)
     val segment2    = assetString.substring(2, 4)
     Path(segment1.toLowerCase, segment2.toLowerCase)

--- a/src/test/scala/swiss/dasch/api/MaintenanceEndpointsSpec.scala
+++ b/src/test/scala/swiss/dasch/api/MaintenanceEndpointsSpec.scala
@@ -75,7 +75,10 @@ object MaintenanceEndpointsSpec extends ZIOSpecDefault {
         def loadAssetInfo(asset: AssetRef) = StorageService.getAssetDirectory(asset).flatMap {
           // Since the create original maintenance action is forked into the background
           // we need to wait (i.e. `awaitTrue') for the file to be created.
-          assetDir => awaitTrue(Files.exists(assetDir / s"${asset.id}.info")) *> AssetInfoService.findByAssetRef(asset)
+          assetDir =>
+            awaitTrue(Files.exists(assetDir / s"${asset.id}.info")) *> AssetInfoService
+              .findByAssetRef(asset)
+              .someOrFail(IllegalStateException("Asset info not found"))
         }
 
         val assetJpx    = AssetRef("aaaa-a-jpx-without-orig".toAssetId, existingProject)

--- a/src/test/scala/swiss/dasch/domain/AssetIdSpec.scala
+++ b/src/test/scala/swiss/dasch/domain/AssetIdSpec.scala
@@ -33,7 +33,7 @@ object AssetIdSpec extends ZIOSpecDefault {
       for {
         _  <- Random.setSeed(1977)
         id <- AssetId.makeNew
-      } yield assertTrue(id.toString == uuid)
+      } yield assertTrue(id.value == uuid)
     }
   )
 }

--- a/src/test/scala/swiss/dasch/domain/AssetIdSpec.scala
+++ b/src/test/scala/swiss/dasch/domain/AssetIdSpec.scala
@@ -16,17 +16,17 @@ object AssetIdSpec extends ZIOSpecDefault {
   val spec = suite("AssetIdSpec")(
     test("AssetId should be created from a valid string") {
       val valid = Gen.stringBounded(4, 20)(validCharacters)
-      check(valid)(s => assertTrue(AssetId.make(s).exists(_.toString == s)))
+      check(valid)(s => assertTrue(AssetId.from(s).exists(_.toString == s)))
     },
     test("AssetId should not be created from an String containing invalid characters") {
       val invalid = Gen.stringBounded(1, 20)(
         Gen.fromIterable(List('/', '!', '$', '%', '&', '(', ')', '=', '?', ' ', '+', '*', '#', '@', '€', '£', '§'))
       )
-      check(invalid)(s => assertTrue(AssetId.make(s).isLeft))
+      check(invalid)(s => assertTrue(AssetId.from(s).isLeft))
     },
     test("AssetId should not be created from a String shorter than four characters") {
       val validButTooShort = Gen.stringBounded(0, 3)(validCharacters)
-      check(validButTooShort)(s => assertTrue(AssetId.make(s).isLeft))
+      check(validButTooShort)(s => assertTrue(AssetId.from(s).isLeft))
     },
     test("AssetId.makeNew should create a UUID in Base 62 encoding") {
       val uuid = "4sAf4AmPeeg-ZjDn3Tot1Zt"

--- a/src/test/scala/swiss/dasch/domain/AssetInfoServiceSpec.scala
+++ b/src/test/scala/swiss/dasch/domain/AssetInfoServiceSpec.scala
@@ -48,7 +48,7 @@ object AssetInfoServiceSpec extends ZIOSpecDefault {
             actual.original.checksum == checksumOriginal,
             actual.derivative.file == assetDir / s"${assetRef.id}.jp2",
             actual.derivative.checksum == checksumDerivative,
-            actual.metadata.isEmpty
+            actual.metadata == EmptyMetadata
           )
         }
       },
@@ -87,9 +87,8 @@ object AssetInfoServiceSpec extends ZIOSpecDefault {
             actual.original.checksum == checksumOriginal,
             actual.derivative.file == assetDir / s"${assetRef.id}.jp2",
             actual.derivative.checksum == checksumDerivative,
-            actual.metadata.contains(
+            actual.metadata ==
               MovingImageMetadata(Dimensions.unsafeFrom(640, 480), duration = 3.14, fps = 60)
-            )
           )
         }
       }

--- a/src/test/scala/swiss/dasch/domain/AssetInfoServiceSpec.scala
+++ b/src/test/scala/swiss/dasch/domain/AssetInfoServiceSpec.scala
@@ -39,7 +39,7 @@ object AssetInfoServiceSpec extends ZIOSpecDefault {
                            |""".stripMargin)
                  )
             // when
-            actual <- AssetInfoService.findByAssetRef(assetRef)
+            actual <- AssetInfoService.findByAssetRef(assetRef).map(_.head)
             // then
           } yield assertTrue(
             actual.assetRef == assetRef,
@@ -79,7 +79,7 @@ object AssetInfoServiceSpec extends ZIOSpecDefault {
                            |}
                            |""".stripMargin)
                  )
-            actual <- AssetInfoService.findByAssetRef(assetRef)
+            actual <- AssetInfoService.findByAssetRef(assetRef).map(_.head)
           } yield assertTrue(
             actual.assetRef == assetRef,
             actual.originalFilename == NonEmptyString.unsafeFrom("250x250.jp2"),

--- a/src/test/scala/swiss/dasch/domain/AssetInfoServiceSpec.scala
+++ b/src/test/scala/swiss/dasch/domain/AssetInfoServiceSpec.scala
@@ -48,7 +48,7 @@ object AssetInfoServiceSpec extends ZIOSpecDefault {
             actual.original.checksum == checksumOriginal,
             actual.derivative.file == assetDir / s"${assetRef.id}.jp2",
             actual.derivative.checksum == checksumDerivative,
-            actual.movingImageMetadata.isEmpty
+            actual.metadata.isEmpty
           )
         }
       },
@@ -87,8 +87,8 @@ object AssetInfoServiceSpec extends ZIOSpecDefault {
             actual.original.checksum == checksumOriginal,
             actual.derivative.file == assetDir / s"${assetRef.id}.jp2",
             actual.derivative.checksum == checksumDerivative,
-            actual.movingImageMetadata.contains(
-              MovingImageMetadata(width = 640, height = 480, duration = 3.14, fps = 60)
+            actual.metadata.contains(
+              MovingImageMetadata(Dimensions.unsafeFrom(640, 480), duration = 3.14, fps = 60)
             )
           )
         }

--- a/src/test/scala/swiss/dasch/domain/FileChecksumServiceLiveSpec.scala
+++ b/src/test/scala/swiss/dasch/domain/FileChecksumServiceLiveSpec.scala
@@ -40,7 +40,7 @@ object FileChecksumServiceLiveSpec extends ZIOSpecDefault {
     },
     test("should verify the checksums of an asset's derivative and original") {
       for {
-        assetInfo      <- AssetInfoService.findByAssetRef(existingAssetRef)
+        assetInfo      <- AssetInfoService.findByAssetRef(existingAssetRef).map(_.head)
         checksumResult <- FileChecksumService.verifyChecksum(assetInfo)
       } yield assertTrue(checksumResult.forall(_.checksumMatches == true))
     }

--- a/src/test/scala/swiss/dasch/domain/ImageServiceLiveSpec.scala
+++ b/src/test/scala/swiss/dasch/domain/ImageServiceLiveSpec.scala
@@ -36,7 +36,7 @@ object ImageServiceLiveSpec extends ZIOSpecDefault {
           _        <- SipiClientMock.setOrientation(OrientationValue.Rotate270CW)
           image    <- imageFile
           backup   <- backupFile
-          info     <- AssetInfoService.findByAssetRef(asset)
+          info     <- AssetInfoService.findByAssetRef(asset).map(_.head)
           infoFile <- AssetInfoService.getInfoFilePath(asset)
           _ <- StorageService.saveJsonFile[AssetInfoFileContent](
                  infoFile,

--- a/src/test/scala/swiss/dasch/domain/IngestServiceSpec.scala
+++ b/src/test/scala/swiss/dasch/domain/IngestServiceSpec.scala
@@ -26,7 +26,7 @@ object IngestServiceSpec extends ZIOSpecDefault {
         // when
         asset <- IngestService.ingestFile(fileToIngest, shortcode)
         // then
-        info              <- AssetInfoService.findByAssetRef(asset.ref)
+        info              <- AssetInfoService.findByAssetRef(asset.ref).map(_.head)
         assetDir          <- StorageService.getAssetDirectory(asset.ref)
         originalFilename   = s"${asset.id}.csv.orig"
         derivativeFilename = s"${asset.id}.csv"

--- a/src/test/scala/swiss/dasch/domain/MovingImageServiceSpec.scala
+++ b/src/test/scala/swiss/dasch/domain/MovingImageServiceSpec.scala
@@ -85,7 +85,9 @@ object MovingImageServiceSpec extends ZIOSpecDefault {
         // when
         metadata <- MovingImageService.extractMetadata(d, c.assetRef)
         // then
-      } yield assertTrue(metadata == MovingImageMetadata(width = 1280, height = 720, duration = 170.84, fps = 25.0))
+      } yield assertTrue(
+        metadata == MovingImageMetadata(Dimensions.unsafeFrom(1280, 720), duration = 170.84, fps = 25.0)
+      )
     },
     test("given invalid metadata it should not extract") {
       val invalidProcessOut = Seq(

--- a/src/test/scala/swiss/dasch/domain/StorageServiceLiveSpec.scala
+++ b/src/test/scala/swiss/dasch/domain/StorageServiceLiveSpec.scala
@@ -63,12 +63,12 @@ object StorageServiceLiveSpec extends ZIOSpecDefault {
         expected = AssetInfo(
                      assetRef = asset,
                      original = FileAndChecksum(
-                       projectPath / "fg" / "il" / s"${asset.id.toString}.jp2.orig",
+                       projectPath / "fg" / "il" / s"${asset.id.value}.jp2.orig",
                        "fb252a4fb3d90ce4ebc7e123d54a4112398a7994541b11aab5e4230eac01a61c".toSha256Hash
                      ),
                      originalFilename = name,
                      derivative = FileAndChecksum(
-                       projectPath / "fg" / "il" / s"${asset.id.toString}.jp2",
+                       projectPath / "fg" / "il" / s"${asset.id.value}.jp2",
                        "0ce405c9b183fb0d0a9998e9a49e39c93b699e0f8e2a9ac3496c349e5cea09cc".toSha256Hash
                      )
                    )

--- a/src/test/scala/swiss/dasch/domain/StorageServiceLiveSpec.scala
+++ b/src/test/scala/swiss/dasch/domain/StorageServiceLiveSpec.scala
@@ -73,7 +73,7 @@ object StorageServiceLiveSpec extends ZIOSpecDefault {
                      )
                    )
         actual <- AssetInfoService.findByAssetRef(asset)
-      } yield assertTrue(expected == actual)
+      } yield assertTrue(Some(expected) == actual)
     },
     suite("create temp directory scoped")(
       test("should create a temp directory") {

--- a/src/test/scala/swiss/dasch/domain/StorageServiceLiveSpec.scala
+++ b/src/test/scala/swiss/dasch/domain/StorageServiceLiveSpec.scala
@@ -73,7 +73,7 @@ object StorageServiceLiveSpec extends ZIOSpecDefault {
                      )
                    )
         actual <- AssetInfoService.findByAssetRef(asset)
-      } yield assertTrue(Some(expected) == actual)
+      } yield assertTrue(actual.contains(expected))
     },
     suite("create temp directory scoped")(
       test("should create a temp directory") {

--- a/src/test/scala/swiss/dasch/test/SpecConstants.scala
+++ b/src/test/scala/swiss/dasch/test/SpecConstants.scala
@@ -23,10 +23,8 @@ object SpecConstants {
   }
   extension (s: String) {
     def toProjectShortcode: ProjectShortcode = ProjectShortcode.unsafeFrom(s)
-    def toAssetId: AssetId = AssetId
-      .make(s)
-      .fold(err => throw new IllegalArgumentException(err), identity)
-    def toSha256Hash: Sha256Hash = Sha256Hash.unsafeFrom(s)
+    def toAssetId: AssetId                   = AssetId.unsafeFrom(s)
+    def toSha256Hash: Sha256Hash             = Sha256Hash.unsafeFrom(s)
     def toNonEmptyString: NonEmptyString =
       NonEmptyString.unsafeFrom(s)
   }


### PR DESCRIPTION
This endpoint returns the asset's `.info` file contents as json.

`GET /projects/<shortcode>/assets/<assetId>/info endpoint`

Sample Response:
```json
{
	"internalFilename": "5IrpYt6Y0j3-FNPJ47uoyw7.jpx",
	"originalInternalFilename": "5IrpYt6Y0j3-FNPJ47uoyw7.jpg.orig",
	"originalFilename": "ir14_ny_m_pfi_10_11_moh-v.jpg",
	"checksumOriginal": "db5e971f4464e93d3cb04257f819e79626176a1db7b153557ffc6cc95bb06cd0",
	"checksumDerivative": "0b1f3b573d10c544334eee714e1887ded617ed10b1a57940f1afc68abfe943a2"
}
```

Extend the `.info` for image files to contain the `width` and `height`, get this information during an ingest.

_Out of scope_
Add a maintenance action which adds image metadata to the `.info` file for all existing assets.