### PR TITLE
fix: Use a stable version for Sipi base image

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -54,6 +54,7 @@ lazy val root = (project in file("."))
       version,
       scalaVersion,
       sbtVersion,
+      BuildInfoKey("sipiVersion", sipiVersion),
       BuildInfoKey.action("gitCommit")(gitCommit)
     ),
     buildInfoOptions += BuildInfoOption.BuildTime,

--- a/build.sbt
+++ b/build.sbt
@@ -8,6 +8,7 @@ addCommandAlias("fmtCheck", "scalafmtCheck; Test / scalafmtCheck;")
 addCommandAlias("headerCreateAll", "; all root/headerCreate Test/headerCreate")
 addCommandAlias("headerCheckAll", "; all root/headerCheck Test/headerCheck")
 
+val sipiVersion                 = "v30.6.0"
 val tapirVersion                = "1.9.5"
 val testContainersVersion       = "0.40.15"
 val zioConfigVersion            = "3.0.7"
@@ -108,7 +109,7 @@ lazy val root = (project in file("."))
     dockerExposedPorts                   := Seq(3340),
     Docker / defaultLinuxInstallLocation := "/sipi",
     dockerUpdateLatest                   := true,
-    dockerBaseImage                      := "daschswiss/knora-sipi:latest",
+    dockerBaseImage                      := s"daschswiss/knora-sipi:$sipiVersion",
     dockerBuildxPlatforms                := Seq("linux/arm64/v8", "linux/amd64"),
     dockerCommands += Cmd(
       """HEALTHCHECK --interval=30s --timeout=10s --retries=3 --start-period=30s \

--- a/src/main/scala/swiss/dasch/infrastructure/CommandExecutorLive.scala
+++ b/src/main/scala/swiss/dasch/infrastructure/CommandExecutorLive.scala
@@ -7,6 +7,7 @@ package swiss.dasch.infrastructure
 
 import swiss.dasch.config.Configuration.SipiConfig
 import swiss.dasch.domain.StorageService
+import swiss.dasch.version.BuildInfo
 import zio.{IO, UIO, ZIO, ZLayer}
 
 import java.io.IOException
@@ -62,7 +63,9 @@ final case class CommandExecutorLive(sipiConfig: SipiConfig, storageService: Sto
     if (sipiConfig.useLocalDev) {
       for {
         assetDir <- storageService.getAssetDirectory().flatMap(_.toAbsolutePath).orDie
-      } yield Command(s"docker run --entrypoint $command -v $assetDir:$assetDir daschswiss/knora-sipi:latest $params")
+      } yield Command(
+        s"docker run --entrypoint $command -v $assetDir:$assetDir daschswiss/knora-sipi:${BuildInfo.sipiVersion} $params"
+      )
     } else {
       ZIO.succeed(Command(s"$command $params"))
     }

--- a/src/test/scala/swiss/dasch/infrastructure/CommandExecutorLiveSpec.scala
+++ b/src/test/scala/swiss/dasch/infrastructure/CommandExecutorLiveSpec.scala
@@ -8,6 +8,7 @@ package swiss.dasch.infrastructure
 import swiss.dasch.config.Configuration.SipiConfig
 import swiss.dasch.domain.{StorageService, StorageServiceLive}
 import swiss.dasch.test.SpecConfigurations
+import swiss.dasch.version.BuildInfo
 import zio.ZLayer
 import zio.test.{ZIOSpecDefault, assertTrue}
 
@@ -20,7 +21,7 @@ object CommandExecutorLiveSpec extends ZIOSpecDefault {
         cmd      <- CommandExecutor.buildCommand("customCommand", "customParams").provideSome[StorageService](devLayer)
         assetDir <- StorageService.getAssetDirectory().flatMap(_.toAbsolutePath)
         expected =
-          s"docker run --entrypoint customCommand -v $assetDir:$assetDir daschswiss/knora-sipi:latest customParams"
+          s"docker run --entrypoint customCommand -v $assetDir:$assetDir daschswiss/knora-sipi:${BuildInfo.sipiVersion} customParams"
       } yield assertTrue(cmd.cmd == expected)
     },
     test("buildCommand without docker when useLocalDev is false") {


### PR DESCRIPTION
We have to use a stable version for the `daschswiss/knora-sipi` container because `dsp-api` publishes unstable versions on each commit on main. Hence the `latest` tag is unsuitable.