### PR TITLE
feat: Add assets overview report

### DIFF
--- a/src/main/scala/swiss/dasch/Endpoints.scala
+++ b/src/main/scala/swiss/dasch/Endpoints.scala
@@ -8,7 +8,12 @@ package swiss.dasch
 import sttp.capabilities.zio.ZioStreams
 import sttp.tapir.swagger.bundle.SwaggerInterpreter
 import sttp.tapir.ztapir.ZServerEndpoint
-import swiss.dasch.api.{MaintenanceEndpointsHandler, MonitoringEndpointsHandler, ProjectsEndpointsHandler, ReportEndpointsHandler}
+import swiss.dasch.api.{
+  MaintenanceEndpointsHandler,
+  MonitoringEndpointsHandler,
+  ProjectsEndpointsHandler,
+  ReportEndpointsHandler
+}
 import swiss.dasch.version.BuildInfo
 import zio.{Task, ZLayer}
 

--- a/src/main/scala/swiss/dasch/Endpoints.scala
+++ b/src/main/scala/swiss/dasch/Endpoints.scala
@@ -8,16 +8,17 @@ package swiss.dasch
 import sttp.capabilities.zio.ZioStreams
 import sttp.tapir.swagger.bundle.SwaggerInterpreter
 import sttp.tapir.ztapir.ZServerEndpoint
-import swiss.dasch.api.{MaintenanceEndpointsHandler, MonitoringEndpointsHandler, ProjectsEndpointsHandler}
+import swiss.dasch.api.{MaintenanceEndpointsHandler, MonitoringEndpointsHandler, ProjectsEndpointsHandler, ReportEndpointsHandler}
 import swiss.dasch.version.BuildInfo
 import zio.{Task, ZLayer}
 
 final case class Endpoints(
   private val monitoring: MonitoringEndpointsHandler,
   private val projects: ProjectsEndpointsHandler,
-  private val maintenance: MaintenanceEndpointsHandler
+  private val maintenance: MaintenanceEndpointsHandler,
+  private val reports: ReportEndpointsHandler
 ) {
-  val api = monitoring.endpoints ++ projects.endpoints ++ maintenance.endpoints
+  val api = monitoring.endpoints ++ projects.endpoints ++ maintenance.endpoints ++ reports.endpoints
 
   val endpoints: List[ZServerEndpoint[Any, ZioStreams]] = {
     val docs = createDocs(api)

--- a/src/main/scala/swiss/dasch/Main.scala
+++ b/src/main/scala/swiss/dasch/Main.scala
@@ -50,7 +50,9 @@ object Main extends ZIOAppDefault {
         ProjectService.layer,
         ProjectsEndpoints.layer,
         ProjectsEndpointsHandler.layer,
-        ReportServiceLive.layer,
+        ReportEndpoints.layer,
+        ReportEndpointsHandler.layer,
+        ReportService.layer,
         SipiClientLive.layer,
         StillImageService.layer,
         StorageServiceLive.layer

--- a/src/main/scala/swiss/dasch/api/ProjectsEndpoints.scala
+++ b/src/main/scala/swiss/dasch/api/ProjectsEndpoints.scala
@@ -86,7 +86,7 @@ object ProjectsEndpointsResponses {
 
     given schema: Schema[AssetCheckResultResponse] = DeriveSchema.gen[AssetCheckResultResponse]
 
-    def from(report: Report): AssetCheckResultResponse = {
+    def from(report: ChecksumReport): AssetCheckResultResponse = {
       val reportResults = report.results
       val results       = reportResults.map { case (info, checksum) => AssetCheckResultEntry.from(info, checksum) }.toList
       val summary = AssetCheckResultSummary(

--- a/src/main/scala/swiss/dasch/api/ReportEndpoints.scala
+++ b/src/main/scala/swiss/dasch/api/ReportEndpoints.scala
@@ -1,3 +1,8 @@
+/*
+ * Copyright © 2021 - 2024 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package swiss.dasch.api
 
 import sttp.model.StatusCode

--- a/src/main/scala/swiss/dasch/api/ReportEndpoints.scala
+++ b/src/main/scala/swiss/dasch/api/ReportEndpoints.scala
@@ -1,0 +1,23 @@
+package swiss.dasch.api
+
+import sttp.model.StatusCode
+import sttp.tapir.ztapir.*
+
+final case class ReportEndpoints(baseEndpoints: BaseEndpoints) {
+
+  private val report      = "report"
+  private val maintenance = "maintenance"
+
+  private[api] val postAssetOverviewReport =
+    baseEndpoints.secureEndpoint.post
+      .in(report / "asset-overview")
+      .out(stringBody)
+      .out(statusCode(StatusCode.Accepted))
+      .tag(maintenance)
+
+  val endpoints = List(postAssetOverviewReport)
+}
+
+object ReportEndpoints {
+  val layer = zio.ZLayer.derive[ReportEndpoints]
+}

--- a/src/main/scala/swiss/dasch/api/ReportEndpointsHandler.scala
+++ b/src/main/scala/swiss/dasch/api/ReportEndpointsHandler.scala
@@ -1,0 +1,25 @@
+package swiss.dasch.api
+
+import sttp.tapir.ztapir.ZServerEndpoint
+import swiss.dasch.domain.*
+import zio.{ZIO, ZLayer}
+
+final class ReportEndpointsHandler(reportEndpoints: ReportEndpoints, reportService: ReportService) {
+
+  private val foo: ZServerEndpoint[Any, Any] = reportEndpoints.postAssetOverviewReport.serverLogic(_ =>
+    _ =>
+      reportService.assetsOverviewReport
+        .tap(report => ZIO.logInfo(report.toString))
+        .forkDaemon
+        .logError
+        .as("work in progress")
+  )
+
+  val endpoints: List[ZServerEndpoint[Any, Any]] =
+    List(foo)
+}
+
+object ReportEndpointsHandler {
+
+  val layer = ZLayer.derive[ReportEndpointsHandler]
+}

--- a/src/main/scala/swiss/dasch/api/ReportEndpointsHandler.scala
+++ b/src/main/scala/swiss/dasch/api/ReportEndpointsHandler.scala
@@ -2,21 +2,33 @@ package swiss.dasch.api
 
 import sttp.tapir.ztapir.ZServerEndpoint
 import swiss.dasch.domain.*
+import zio.stream.ZStream
 import zio.{ZIO, ZLayer}
 
-final class ReportEndpointsHandler(reportEndpoints: ReportEndpoints, reportService: ReportService) {
+final class ReportEndpointsHandler(
+  reportEndpoints: ReportEndpoints,
+  reportService: ReportService,
+  projectService: ProjectService
+) {
 
-  private val foo: ZServerEndpoint[Any, Any] = reportEndpoints.postAssetOverviewReport.serverLogic(_ =>
-    _ =>
-      reportService.assetsOverviewReport
-        .tap(report => ZIO.logInfo(report.toString))
-        .forkDaemon
-        .logError
-        .as("work in progress")
-  )
+  private val postAssetOverviewReportHandler: ZServerEndpoint[Any, Any] =
+    reportEndpoints.postAssetOverviewReport.serverLogic(_ =>
+      _ => createAssetOverReports.forkDaemon.logError.as("work in progress")
+    )
+
+  private val createAssetOverReports: ZIO[Any, Throwable, Unit] =
+    for {
+      reports <- ZStream
+                   .fromIterableZIO(projectService.listAllProjects().map(_.map(_.shortcode)))
+                   .mapZIO(prj => reportService.assetsOverviewReport(prj))
+                   .runCollect
+                   .map(_.flatten)
+      report <- reportService.saveReport("asset-overview", reports).flatMap(_.toAbsolutePath)
+      _      <- ZIO.logInfo(s"Created $report asset overview reports")
+    } yield ()
 
   val endpoints: List[ZServerEndpoint[Any, Any]] =
-    List(foo)
+    List(postAssetOverviewReportHandler)
 }
 
 object ReportEndpointsHandler {

--- a/src/main/scala/swiss/dasch/api/ReportEndpointsHandler.scala
+++ b/src/main/scala/swiss/dasch/api/ReportEndpointsHandler.scala
@@ -1,3 +1,8 @@
+/*
+ * Copyright © 2021 - 2024 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package swiss.dasch.api
 
 import sttp.tapir.ztapir.ZServerEndpoint

--- a/src/main/scala/swiss/dasch/domain/StorageService.scala
+++ b/src/main/scala/swiss/dasch/domain/StorageService.scala
@@ -66,6 +66,8 @@ trait StorageService {
   def deleteRecursive(path: Path): IO[IOException, Long]
 
   def deleteDirectoryIfEmpty(directory: Path): IO[IOException, Unit]
+
+  def calculateSizeInBytes(path: Path): Task[BigInt]
 }
 
 object StorageService {
@@ -164,6 +166,31 @@ final case class StorageServiceLive(config: StorageConfig) extends StorageServic
       .catchSome { case _: DirectoryNotEmptyException => ZIO.unit }
       .whenZIO(Files.isDirectory(directory))
       .unit
+
+  /**
+   * Returns the size of a non hidden regular file or the total size of all non hidden files in a directory in bytes.
+   * @param path the path to the file or directory
+   * @return the size in bytes, or 0 if the file is neither a non hidden regular file or a directory
+   */
+  override def calculateSizeInBytes(path: Path): Task[BigInt] =
+    Files.isDirectory(path).flatMap {
+      case true  => calculateDirectorySize(path)
+      case false => calculateFileSize(path)
+    }
+
+  private def calculateDirectorySize(path: Path): ZIO[Any, IOException, BigInt] =
+    Files
+      .walk(path)
+      .filterZIO(p => FileFilters.isNonHiddenRegularFile(p))
+      .mapZIO(Files.size)
+      .map(BigInt.apply)
+      .runSum
+
+  private def calculateFileSize(path: Path): ZIO[Any, IOException, BigInt] =
+    FileFilters.isNonHiddenRegularFile.apply(path).flatMap {
+      case false => ZIO.succeed(BigInt(0))
+      case true  => Files.size(path).map(BigInt.apply)
+    }
 }
 
 object StorageServiceLive {

--- a/src/main/scala/swiss/dasch/domain/SupportedFileType.scala
+++ b/src/main/scala/swiss/dasch/domain/SupportedFileType.scala
@@ -6,6 +6,7 @@
 package swiss.dasch.domain
 
 import swiss.dasch.domain.PathOps.fileExtension
+import zio.json.JsonCodec
 import zio.nio.file.Path
 
 private val archive = Map(
@@ -69,7 +70,7 @@ private val stillImages = Map(
  *
  * @param extensions the file extensions of the supported file types.
  */
-enum SupportedFileType(val mappings: Map[String, MimeType]) {
+enum SupportedFileType(val mappings: Map[String, MimeType]) derives JsonCodec {
   case StillImage  extends SupportedFileType(stillImages)
   case MovingImage extends SupportedFileType(movingImages)
   case OtherFiles  extends SupportedFileType(other)

--- a/src/test/scala/swiss/dasch/api/ProjectsEndpointSpec.scala
+++ b/src/test/scala/swiss/dasch/api/ProjectsEndpointSpec.scala
@@ -303,7 +303,7 @@ object ProjectsEndpointSpec extends ZIOSpecDefault {
     ProjectService.layer,
     ProjectsEndpoints.layer,
     ProjectsEndpointsHandler.layer,
-    ReportServiceLive.layer,
+    ReportService.layer,
     SipiClientMock.layer,
     SpecConfigurations.ingestConfigLayer,
     SpecConfigurations.jwtConfigDisableAuthLayer,


### PR DESCRIPTION
Adds endpoint to trigger the asynchronous creation of the report in `tmp/reports/asset-overview_YYY-MM-DDTHH:MM:SS.NNNNNZ.json`
```http
POST http://0.0.0.0:3340/report/asset-overview
Authorization: Bearer foo
```

Produces a report like this:

```json
[
  {
    "shortcode" : "0001",
    "totalNrOfAssets" : 5,
    "nrOfAssetsPerType" : {
      "StillImage" : 5
    },
    "sizesPerType" : {
      "sizes" : {
        "StillImage" : {
          "SizeInBytesOther" : {
            "fileType" : {
              "StillImage" : {}
            },
            "sizeOrig" : "54,48 KiB",
            "sizeDerivative" : "14,91 KiB"
          }
        }
      }
    }
  },
  {
    "shortcode" : "0002",
    "totalNrOfAssets" : 4,
    "nrOfAssetsPerType" : {
      "MovingImage" : 1,
      "StillImage" : 2,
      "OtherFiles" : 1
    },
    "sizesPerType" : {
      "sizes" : {
        "MovingImage" : {
          "SizeInBytesMovingImages" : {
            "sizeOrig" : "30,03 MiB",
            "sizeDerivative" : "30,03 MiB",
            "sizeKeyframes" : "115,27 KiB"
          }
        },
        "StillImage" : {
          "SizeInBytesOther" : {
            "fileType" : {
              "StillImage" : {}
            },
            "sizeOrig" : "1,11 MiB",
            "sizeDerivative" : "1007,35 KiB"
          }
        },
        "OtherFiles" : {
          "SizeInBytesOther" : {
            "fileType" : {
              "OtherFiles" : {}
            },
            "sizeOrig" : "3,00 B",
            "sizeDerivative" : "3,00 B"
          }
        }
      }
    }
  }
]
```