### PR TITLE
chore: Fix failing docker build while installing dependencies because of missing 'apt-update'

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -122,7 +122,7 @@ lazy val root = (project in file("."))
     // Install Temurin Java 21 https://adoptium.net/de/installation/linux/
     dockerCommands += Cmd(
       "RUN",
-      "apt install -y wget apt-transport-https && wget -qO - https://packages.adoptium.net/artifactory/api/gpg/key/public | gpg --dearmor | tee /etc/apt/trusted.gpg.d/adoptium.gpg > /dev/null",
+      "apt update && apt install -y wget apt-transport-https && wget -qO - https://packages.adoptium.net/artifactory/api/gpg/key/public | gpg --dearmor | tee /etc/apt/trusted.gpg.d/adoptium.gpg > /dev/null",
     ),
     dockerCommands += Cmd(
       "RUN",


### PR DESCRIPTION
Failing build on main branch:
https://github.com/dasch-swiss/dsp-ingest/actions/runs/8519129341/job/23332595535

Locally I was able to determine that the first `apt install` already fails, needs an `apt update` first.