### PR TITLE
docs: Add docs for endpoint authorization (DEV-3452)

### DIFF
--- a/docs/api-authentication.md
+++ b/docs/api-authentication.md
@@ -9,12 +9,22 @@ where `<token>` is a [JWT](https://jwt.io/) token issued by the DSP-API.
 The token is a JSON Web Token (JWT) that must contain the following claims:
 
 * `iss` (issuer): The issuer of the token, the DSP-API
-* `sub` (subject): The subject of the token, the user's or system id
+* `sub` (subject): The subject of the token, grants access to certain routes, format described [below](#authorization-and-subject-format).
 * `aud` (audience): The audience of the token, the Dsp-Ingest service specific audience
 * `exp` (expiration time): The expiration time of the token, in seconds since epoch
 * `iat` (issued at): The time at which the token was issued, in seconds since epoch
 * `jti` (JWT ID): A unique identifier for the token
 
-# Permissions and Authorization
+# Authorization and subject format
 
-Currently, no further authorization is done, but this will change in the future.
+Subject should be either empty or contain an object of form `{"scope": "admin"}`
+where the value should contain space-delimited string combined from allowed values:
+
+* `admin` – allows access to any route requiring authorization,
+* `write:project:1234` – grants writing permissions for project with the shortcode `1234`.
+* `read:project:1234` – grants reading permissions for project with the shortcode `1234`.
+* `badvalue` – unrecognized values will be ignored for future-compatibility.
+
+Example subject contents:
+* "" or _empty_
+* `write:project:ABCD read:project:8F8F write:project:1A2B`.

--- a/src/main/scala/swiss/dasch/api/MaintenanceEndpoints.scala
+++ b/src/main/scala/swiss/dasch/api/MaintenanceEndpoints.scala
@@ -67,24 +67,28 @@ final case class MaintenanceEndpoints(base: BaseEndpoints) {
     .out(stringBody)
     .out(statusCode(StatusCode.Accepted))
     .tag(maintenance)
+    .description("Authorization: admin scope required.")
 
   val needsTopLeftCorrectionEndpoint = base.secureEndpoint.get
     .in(maintenance / "needs-top-left-correction")
     .out(stringBody)
     .out(statusCode(StatusCode.Accepted))
     .tag(maintenance)
+    .description("Authorization: admin scope required.")
 
   val wasTopLeftCorrectionAppliedEndpoint = base.secureEndpoint.get
     .in(maintenance / "was-top-left-correction-applied")
     .out(stringBody)
     .out(statusCode(StatusCode.Accepted))
     .tag(maintenance)
+    .description("Authorization: admin scope required.")
 
   val createOriginalsEndpoint = base.secureEndpoint.post
     .in(maintenance / "create-originals" / shortcodePathVar)
     .in(jsonBody[Chunk[MappingEntry]])
     .out(statusCode(StatusCode.Accepted))
     .tag(maintenance)
+    .description("Authorization: admin scope required.")
 
   val needsOriginalsEndpoint = base.secureEndpoint.get
     .in(maintenance / "needs-originals")
@@ -92,6 +96,7 @@ final case class MaintenanceEndpoints(base: BaseEndpoints) {
     .out(stringBody)
     .out(statusCode(StatusCode.Accepted))
     .tag(maintenance)
+    .description("Authorization: admin scope required.")
 
   val endpoints = List(
     postMaintenanceActionEndpoint,

--- a/src/main/scala/swiss/dasch/api/ProjectsEndpoints.scala
+++ b/src/main/scala/swiss/dasch/api/ProjectsEndpoints.scala
@@ -145,7 +145,6 @@ object ProjectsEndpointsResponses {
 }
 
 final case class ProjectsEndpoints(base: BaseEndpoints) {
-
   private val projects = "projects"
 
   val getProjectsEndpoint = base.secureEndpoint.get
@@ -153,21 +152,25 @@ final case class ProjectsEndpoints(base: BaseEndpoints) {
     .out(jsonBody[Chunk[ProjectResponse]])
     .out(header[String](HeaderNames.ContentRange))
     .tag(projects)
+    .description("Authorization: admin scope required.")
 
   val getProjectByShortcodeEndpoint = base.secureEndpoint.get
     .in(projects / shortcodePathVar)
     .out(jsonBody[ProjectResponse])
     .tag(projects)
+    .description("Authorization: read:project:1234 scope required.")
 
   val getProjectsChecksumReport = base.secureEndpoint.get
     .in(projects / shortcodePathVar / "checksumreport")
     .out(jsonBody[AssetCheckResultResponse])
     .tag(projects)
+    .description("Authorization: read:project:1234 scope required.")
 
   val getProjectsAssetsInfo = base.secureEndpoint.get
     .in(projects / shortcodePathVar / "assets" / path[AssetId]("assetId"))
     .out(jsonBody[AssetInfoResponse])
     .tag("assets")
+    .description("Authorization: read:project:1234 scope required.")
 
   val postBulkIngest = base.secureEndpoint.post
     .in(projects / shortcodePathVar / "bulk-ingest")
@@ -176,7 +179,8 @@ final case class ProjectsEndpoints(base: BaseEndpoints) {
     .description(
       "Triggers an ingest on the project with the given shortcode. " +
         "Currently only supports ingest of images. " +
-        "The files are expected to be in the `tmp/<project_shortcode>` directory.",
+        "The files are expected to be in the `tmp/<project_shortcode>` directory. " +
+        "Authorization: admin scope required.",
     )
     .tag("bulk-ingest")
 
@@ -186,7 +190,8 @@ final case class ProjectsEndpoints(base: BaseEndpoints) {
     .description(
       "Finalizes the bulk ingest. " +
         "This will remove the files from the `tmp/<project_shortcode>` directory and the directory itself. " +
-        "This will remove also the mapping.csv file.",
+        "This will remove also the mapping.csv file. " +
+        "Authorization: admin scope required.",
     )
     .tag("bulk-ingest")
 
@@ -194,8 +199,8 @@ final case class ProjectsEndpoints(base: BaseEndpoints) {
     .in(projects / shortcodePathVar / "bulk-ingest" / "mapping.csv")
     .description(
       "Get the current result of the bulk ingest, may be incomplete. " +
-        "The result is a csv with the following structure: " +
-        "original,derivative",
+        "The result is a csv with the following structure: `original,derivative`. " +
+        "Authorization: admin scope required.",
     )
     .out(stringBody)
     .out(header(HeaderNames.ContentType, "text/csv"))
@@ -208,6 +213,7 @@ final case class ProjectsEndpoints(base: BaseEndpoints) {
     .out(header[String]("Content-Type"))
     .out(streamBinaryBody(ZioStreams)(CodecFormat.Zip()))
     .tag("import/export")
+    .description("Authorization: admin scope required.")
 
   val getImport = base.secureEndpoint
     .in(projects / shortcodePathVar / "import")
@@ -215,6 +221,7 @@ final case class ProjectsEndpoints(base: BaseEndpoints) {
     .in(header("Content-Type", "application/zip"))
     .out(jsonBody[UploadResponse])
     .tag("import/export")
+    .description("Authorization: admin scope required.")
 
   val endpoints =
     List(


### PR DESCRIPTION
1. The endpoint descriptions look roughly like this:
<kbd><img width="379" alt="Screenshot 2024-04-22 at 16 01 19" src="https://github.com/dasch-swiss/dsp-ingest/assets/235147/8357fa2e-c3ca-4953-ac81-1fbde653bd45"></kbd>

I tried to make common code to append the descriptions, but it wasn't so easy and I didn't want to delve into the tapir implementation details to match the right type to add the implicits.

2. The authorization markdown page update looks like this:
<kbd><img width="803" alt="Screenshot 2024-04-22 at 15 28 20" src="https://github.com/dasch-swiss/dsp-ingest/assets/235147/fe1ea93b-182a-4c73-a012-2ee738152a4b"></kbd>
