### PR TITLE
fix: Create the project folder if it does not exist yet when ingesting individual assets (DEV-3620)

### DIFF
--- a/src/main/scala/swiss/dasch/api/ProjectsEndpointsHandler.scala
+++ b/src/main/scala/swiss/dasch/api/ProjectsEndpointsHandler.scala
@@ -94,7 +94,7 @@ final case class ProjectsEndpointsHandler(
       authorizationHandler.ensureProjectWritable(principal, shortcode) *>
         ZIO.scoped {
           for {
-            prj <- projectService.findProject(shortcode).some.mapError(projectNotFoundOrServerError(_, shortcode))
+            prj <- projectService.findOrCreateProject(shortcode).mapError(InternalServerError(_))
             tmpDir <-
               storageService.createTempDirectoryScoped(s"${prj.shortcode}-ingest").mapError(InternalServerError(_))
             tmpFile = tmpDir / filename.value

--- a/src/main/scala/swiss/dasch/domain/ProjectService.scala
+++ b/src/main/scala/swiss/dasch/domain/ProjectService.scala
@@ -56,6 +56,12 @@ final case class ProjectService(
       .getProjectFolder(shortcode)
       .flatMap(path => ZIO.whenZIO(Files.isDirectory(path))(ZIO.succeed(path)))
 
+  def findOrCreateProject(shortcode: ProjectShortcode): IO[IOException, ProjectFolder] =
+    findProject(shortcode).flatMap {
+      case Some(prj) => ZIO.succeed(prj)
+      case None      => storage.createProjectFolder(shortcode)
+    }
+
   def findAssetInfosOfProject(shortcode: ProjectShortcode): ZStream[Any, Throwable, AssetInfo] =
     ZStream
       .fromZIOOption(findProject(shortcode).some)

--- a/src/main/scala/swiss/dasch/domain/StorageService.scala
+++ b/src/main/scala/swiss/dasch/domain/StorageService.scala
@@ -112,9 +112,7 @@ final case class StorageServiceLive(config: StorageConfig) extends StorageServic
     ZIO.succeed(AssetsBaseFolder.from(config))
 
   override def createProjectFolder(shortcode: ProjectShortcode): IO[IOException, ProjectFolder] =
-    getAssetsBaseFolder()
-      .map(assetDir => ProjectFolder.unsafeFrom(assetDir / shortcode.toString))
-      .tap(f => createDirectories(f.path))
+    getProjectFolder(shortcode).tap(f => createDirectories(f.path))
 
   override def getProjectFolder(shortcode: ProjectShortcode): UIO[ProjectFolder] =
     getAssetsBaseFolder().map(assetDir => ProjectFolder.unsafeFrom(assetDir / shortcode.toString))

--- a/src/main/scala/swiss/dasch/domain/StorageService.scala
+++ b/src/main/scala/swiss/dasch/domain/StorageService.scala
@@ -23,6 +23,7 @@ import java.time.format.DateTimeFormatter
 import java.time.{ZoneId, ZoneOffset}
 
 trait StorageService {
+  def createProjectFolder(projectShortcode: ProjectShortcode): IO[IOException, ProjectFolder]
   def getProjectFolder(projectShortcode: ProjectShortcode): UIO[ProjectFolder]
   def getAssetFolder(asset: AssetRef): UIO[AssetFolder]
   def getAssetsBaseFolder(): UIO[AssetsBaseFolder]
@@ -109,6 +110,11 @@ final case class StorageServiceLive(config: StorageConfig) extends StorageServic
 
   override def getAssetsBaseFolder(): UIO[AssetsBaseFolder] =
     ZIO.succeed(AssetsBaseFolder.from(config))
+
+  override def createProjectFolder(shortcode: ProjectShortcode): IO[IOException, ProjectFolder] =
+    getAssetsBaseFolder()
+      .map(assetDir => ProjectFolder.unsafeFrom(assetDir / shortcode.toString))
+      .tap(f => createDirectories(f.path))
 
   override def getProjectFolder(shortcode: ProjectShortcode): UIO[ProjectFolder] =
     getAssetsBaseFolder().map(assetDir => ProjectFolder.unsafeFrom(assetDir / shortcode.toString))


### PR DESCRIPTION
When ingesting files to a non-existing project the ingest fails because of the project folder not existing.
Create the project folder in this case.
