### PR TITLE
fix: Fix BulkIngestService locking for forked fibers (DEV-3769)

### DIFF
--- a/src/test/scala/swiss/dasch/domain/BulkIngestServiceSpec.scala
+++ b/src/test/scala/swiss/dasch/domain/BulkIngestServiceSpec.scala
@@ -5,8 +5,8 @@
 
 package swiss.dasch.domain
 
-import swiss.dasch.api.SipiClientMock
-import swiss.dasch.infrastructure.CommandExecutorMock
+// import swiss.dasch.api.SipiClientMock
+// import swiss.dasch.infrastructure.CommandExecutorMock
 import swiss.dasch.test.SpecConfigurations
 import zio.nio.file.Files
 import zio.test.{ZIOSpecDefault, assertTrue}
@@ -15,6 +15,11 @@ import zio.*
 import java.io.IOException
 import zio.test.TestAspect
 import zio.stream.ZStream
+import zio.nio.file.Path
+import swiss.dasch.domain.Asset.StillImageAsset
+import swiss.dasch.domain.AugmentedPath.OrigFile
+import eu.timepit.refined.types.string.NonEmptyString
+import swiss.dasch.domain.AugmentedPath.JpxDerivativeFile
 
 object BulkIngestServiceSpec extends ZIOSpecDefault {
   // accessor functions for testing
@@ -28,8 +33,43 @@ object BulkIngestServiceSpec extends ZIOSpecDefault {
   ): ZIO[BulkIngestService, Option[IOException], Option[String]] =
     ZIO.serviceWithZIO[BulkIngestService](_.getBulkIngestMappingCsv(shortcode))
 
+  private def bulkIngestService = ZIO.serviceWithZIO[BulkIngestService]
+
+  private val shortcode = ProjectShortcode.unsafeFrom("0001")
+
+  object TestData {
+    val path    = zio.http.Path("a/b/c.tiff")
+    val assetId = AssetId.from("aaaa").toOption.get
+    val stillImageAsset = StillImageAsset(
+      AssetRef(assetId, ProjectShortcode.unsafeFrom("0001")),
+      Original(OrigFile.from("original.jpg.orig").toOption.get, NonEmptyString.from("original.jpg").toOption.get),
+      JpxDerivativeFile.from("original.jpx").toOption.get,
+      StillImageMetadata(Dimensions.unsafeFrom(6, 6), None, None),
+    )
+  }
+
+  val blockIngestSemaphore: Semaphore =
+    Unsafe.unsafe(implicit unsafe => runtime.unsafe.run(Semaphore.make(1)).getOrThrowFiberFailure())
+
+  private val startBulkIngestSuite = suite("start ingest")(test("lock project while ingesting") {
+    for {
+      importDir <- StorageService
+                     .getTempFolder()
+                     .map(_ / "import" / shortcode.value)
+                     .tap(Files.createDirectories(_))
+      _ <- Files.createFile(importDir / "0001.tif")
+      ingestResultFiber <-
+        blockIngestSemaphore.withPermit {
+          for {
+            ingestResultFiber <- bulkIngestService(_.startBulkIngest(shortcode))
+            _                 <- bulkIngestService(_.startBulkIngest(shortcode)).flip
+          } yield ingestResultFiber
+        }
+      ingestResult <- ingestResultFiber.join
+    } yield assertTrue(ingestResult == IngestResult(1, 0))
+  })
+
   private val finalizeBulkIngestSuite = suite("finalize bulk ingest should")(test("remove all files") {
-    val shortcode = ProjectShortcode.unsafeFrom("0001")
     for {
       // given
       importDir <- StorageService
@@ -93,23 +133,35 @@ object BulkIngestServiceSpec extends ZIOSpecDefault {
     } yield assertTrue(file == Chunk(0))
   })
 
+  val MockIngestServiceLayer = ZLayer[Any, Nothing, IngestService](
+    ZIO.succeed(
+      new IngestService {
+        override def ingestFile(fileToIngest: Path, project: ProjectShortcode): Task[Asset] =
+          blockIngestSemaphore.withPermit(
+            ZIO.succeed(TestData.stillImageAsset),
+          )
+      },
+    ),
+  )
+
   val spec = suite("BulkIngestServiceLive")(
+    startBulkIngestSuite,
     finalizeBulkIngestSuite,
     getBulkIngestMappingCsvSuite,
     checkSemaphoresReleased,
     postBulkIngestEndpointSuite,
   ).provide(
-    AssetInfoServiceLive.layer,
     BulkIngestService.layer,
-    CommandExecutorMock.layer,
-    IngestService.layer,
-    MimeTypeGuesser.layer,
-    MovingImageService.layer,
-    OtherFilesService.layer,
-    SipiClientMock.layer,
+    MockIngestServiceLayer,
     SpecConfigurations.ingestConfigLayer,
     SpecConfigurations.storageConfigLayer,
-    StillImageService.layer,
     StorageServiceLive.layer,
+    // SipiClientMock.layer,
+    // CommandExecutorMock.layer,
+    // AssetInfoServiceLive.layer,
+    // MovingImageService.layer,
+    // StillImageService.layer,
+    // OtherFilesService.layer,
+    // MimeTypeGuesser.layer,
   ) @@ TestAspect.timeout(1.second)
 }

--- a/src/test/scala/swiss/dasch/domain/BulkIngestServiceSpec.scala
+++ b/src/test/scala/swiss/dasch/domain/BulkIngestServiceSpec.scala
@@ -25,7 +25,7 @@ object BulkIngestServiceSpec extends ZIOSpecDefault {
   // accessor functions for testing
   private def finalizeBulkIngest(
     shortcode: ProjectShortcode,
-  ): ZIO[BulkIngestService, Option[Nothing], Fiber.Runtime[IOException, Unit]] =
+  ): ZIO[BulkIngestService, Unit, Fiber.Runtime[IOException, Unit]] =
     ZIO.serviceWithZIO[BulkIngestService](_.finalizeBulkIngest(shortcode))
 
   private def getBulkIngestMappingCsv(


### PR DESCRIPTION
The problem lied in an omited `.some` in the `acquireWithTimeout`. Tests for `startBulkIngest` aded also.