### PR TITLE
fix: Handle denormalized filenames in asset upload (DEV-3974)

### DIFF
--- a/src/main/scala/swiss/dasch/domain/AssetFilename.scala
+++ b/src/main/scala/swiss/dasch/domain/AssetFilename.scala
@@ -7,14 +7,18 @@ package swiss.dasch.domain
 
 import zio.nio.file.*
 
+import java.text.Normalizer
+
 final case class AssetFilename private (value: String) extends AnyVal
 
 object AssetFilename {
   // Allow letters, numbers, underscores, hyphens, spaces, full stops, comma, single quote, apostrophe and braces
   private val regex = """^[\p{L}\p{N}_\- .,'`()]+$""".r
 
-  def from(value: String): Either[String, AssetFilename] = {
+  def from(valueUnnormalized: String): Either[String, AssetFilename] = {
+    val value       = Normalizer.normalize(valueUnnormalized, Normalizer.Form.NFC)
     val valueAsPath = Path(value)
+
     for {
       _ <- if (valueAsPath.normalize.filename.toString != value) {
              Left("Filename must not contain any path information")


### PR DESCRIPTION
Frontend should not be sending them in the first place, but ok.

FYI: denormalized means ā = a + ¯ in the unicode sequence instead of the specialized, combined character https://www.compart.com/en/unicode/U+0101.