### PR TITLE
fix: Revert 99b57dba3 "Handle denormalized filenames in asset upload (DEV-3974) (#254)"

### DIFF
--- a/src/main/scala/swiss/dasch/domain/AssetFilename.scala
+++ b/src/main/scala/swiss/dasch/domain/AssetFilename.scala
@@ -7,18 +7,14 @@ package swiss.dasch.domain
 
 import zio.nio.file.*
 
-import java.text.Normalizer
-
 final case class AssetFilename private (value: String) extends AnyVal
 
 object AssetFilename {
   // Allow letters, numbers, underscores, hyphens, spaces, full stops, comma, single quote, apostrophe and braces
   private val regex = """^[\p{L}\p{N}_\- .,'`()]+$""".r
 
-  def from(valueUnnormalized: String): Either[String, AssetFilename] = {
-    val value       = Normalizer.normalize(valueUnnormalized, Normalizer.Form.NFC)
+  def from(value: String): Either[String, AssetFilename] = {
     val valueAsPath = Path(value)
-
     for {
       _ <- if (valueAsPath.normalize.filename.toString != value) {
              Left("Filename must not contain any path information")

--- a/src/test/scala/swiss/dasch/api/ProjectsEndpointSpec.scala
+++ b/src/test/scala/swiss/dasch/api/ProjectsEndpointSpec.scala
@@ -5,34 +5,20 @@
 
 package swiss.dasch.api
 
-import sttp.tapir.server.ziohttp.ZioHttpInterpreter
-import sttp.tapir.server.ziohttp.ZioHttpServerOptions
-import swiss.dasch.api.ProjectsEndpointsResponses.AssetInfoResponse
-import swiss.dasch.api.ProjectsEndpointsResponses.ProjectResponse
-import swiss.dasch.config.Configuration.Features
-import swiss.dasch.config.Configuration.StorageConfig
-import swiss.dasch.domain.AugmentedPath.Conversions.given_Conversion_AugmentedPath_Path
+import sttp.tapir.server.ziohttp.{ZioHttpInterpreter, ZioHttpServerOptions}
+import swiss.dasch.api.ProjectsEndpointsResponses.{AssetInfoResponse, ProjectResponse}
+import swiss.dasch.config.Configuration.{Features, StorageConfig}
 import swiss.dasch.domain.*
+import swiss.dasch.domain.AugmentedPath.Conversions.given_Conversion_AugmentedPath_Path
 import swiss.dasch.infrastructure.CommandExecutorLive
-import swiss.dasch.test.SpecConfigurations
-import swiss.dasch.test.SpecConstants.Projects.emptyProject
-import swiss.dasch.test.SpecConstants.Projects.existingProject
-import swiss.dasch.test.SpecConstants.Projects.nonExistentProject
-import swiss.dasch.test.SpecPaths
+import swiss.dasch.test.SpecConstants.Projects.{emptyProject, existingProject, nonExistentProject}
+import swiss.dasch.test.{SpecConfigurations, SpecPaths}
 import swiss.dasch.util.TestUtils
-import zio.Chunk
-import zio.UIO
-import zio.ZIO
-import zio.ZLayer
-import zio.http
+import zio.{Chunk, UIO, ZIO, ZLayer, http}
 import zio.http.*
 import zio.json.*
 import zio.nio.file.Files
-import zio.test.ZIOSpecDefault
-import zio.test.assertTrue
-
-import java.net.URLDecoder
-import java.text.Normalizer
+import zio.test.{ZIOSpecDefault, assertTrue}
 
 object ProjectsEndpointSpec extends ZIOSpecDefault {
 
@@ -293,20 +279,6 @@ object ProjectsEndpointSpec extends ZIOSpecDefault {
           .post(URL(Path.root / "projects" / "0666" / "assets" / "ingest" / "sample.mp3"), Body.fromString("tegxd"))
           .addHeader("Authorization", "Bearer fakeToken")
         executeRequest(req).map(response => assertTrue(response.status == Status.Ok))
-      },
-      test("should handle ingest denormalized filenames") {
-        val encoded     = "a%CC%84.mp3"
-        val decoded     = URLDecoder.decode(encoded, "UTF-8")
-        val decodedNorm = Normalizer.normalize(decoded, Normalizer.Form.NFC)
-
-        val url = URL(Path.root / "projects" / "0666" / "assets" / "ingest" / encoded)
-        val req = Request
-          .post(url, Body.fromString("tegxd"))
-          .addHeader("Authorization", "Bearer fakeToken")
-
-        executeRequest(req).map { response =>
-          assertTrue(response.status == Status.Ok) && assertTrue(decodedNorm == "ā.mp3")
-        }
       },
       test("should refuse ingesting without content") {
         val req = Request


### PR DESCRIPTION
… (#254)"

This reverts commit 99b57dba31ff85d564cf7d4068a4c08855296041.