### PR TITLE
fix: Always create dirs, use db as primary info source (DEV-3974) + unrevert

### DIFF
--- a/src/main/scala/swiss/dasch/domain/AssetFilename.scala
+++ b/src/main/scala/swiss/dasch/domain/AssetFilename.scala
@@ -7,14 +7,18 @@ package swiss.dasch.domain
 
 import zio.nio.file.*
 
+import java.text.Normalizer
+
 final case class AssetFilename private (value: String) extends AnyVal
 
 object AssetFilename {
   // Allow letters, numbers, underscores, hyphens, spaces, full stops, comma, single quote, apostrophe and braces
   private val regex = """^[\p{L}\p{N}_\- .,'`()]+$""".r
 
-  def from(value: String): Either[String, AssetFilename] = {
+  def from(valueUnnormalized: String): Either[String, AssetFilename] = {
+    val value       = Normalizer.normalize(valueUnnormalized, Normalizer.Form.NFC)
     val valueAsPath = Path(value)
+
     for {
       _ <- if (valueAsPath.normalize.filename.toString != value) {
              Left("Filename must not contain any path information")

--- a/src/main/scala/swiss/dasch/domain/ProjectService.scala
+++ b/src/main/scala/swiss/dasch/domain/ProjectService.scala
@@ -47,7 +47,8 @@ final case class ProjectService(
       .flatMap(path => ZIO.whenZIO(Files.isDirectory(path))(ZIO.succeed(path)))
 
   def findOrCreateProject(shortcode: ProjectShortcode): IO[IOException | SQLException, ProjectFolder] =
-    findProject(shortcode).someOrElseZIO(projectRepo.addProject(shortcode) *> storage.createProjectFolder(shortcode))
+    projectRepo.findByShortcode(shortcode).someOrElseZIO(projectRepo.addProject(shortcode)) *>
+      storage.createProjectFolder(shortcode)
 
   def findAssetInfosOfProject(shortcode: ProjectShortcode): ZStream[Any, Throwable, AssetInfo] =
     ZStream


### PR DESCRIPTION
Seems like this should work, it does locally. Assuming the problem was not with the fix (see the unreverted commit), but with the directories.

When the directory wasn't present, it tried to insert the record in the db, which failed due to unique constraints. Though I still have not found the explanation for the case where the project ID is made up. Maybe the project data missing somewhere else triggers this. 