### PR TITLE
chore: Revert Minor dependency updates (#279)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ addCommandAlias("fmtCheck", "scalafmtCheck; Test / scalafmtCheck;")
 addCommandAlias("headerCreateAll", "; all root/headerCreate Test/headerCreate")
 addCommandAlias("headerCheckAll", "; all root/headerCheck Test/headerCheck")
 
-val flywayVersion               = "10.19.0"
+val flywayVersion               = "10.18.2"
 val hikariVersion               = "6.0.0"
 val quillVersion                = "4.8.5"
 val sipiVersion                 = "v30.18.3"
@@ -95,7 +95,7 @@ lazy val root = (project in file("."))
       "dev.zio"                       %% "zio-prelude"                       % zioPreludeVersion,
       "dev.zio"                       %% "zio-streams"                       % zioVersion,
       "eu.timepit"                    %% "refined"                           % "0.11.2",
-      "com.softwaremill.sttp.client3" %% "zio"                               % "3.10.0",
+      "com.softwaremill.sttp.client3" %% "zio"                               % "3.9.8",
 
       // csv for reports
       "com.github.tototoshi" %% "scala-csv" % "2.0.0",

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ addCommandAlias("fmtCheck", "scalafmtCheck; Test / scalafmtCheck;")
 addCommandAlias("headerCreateAll", "; all root/headerCreate Test/headerCreate")
 addCommandAlias("headerCheckAll", "; all root/headerCheck Test/headerCheck")
 
-val flywayVersion               = "10.18.2"
+val flywayVersion               = "10.19.0"
 val hikariVersion               = "6.0.0"
 val quillVersion                = "4.8.5"
 val sipiVersion                 = "v30.18.3"


### PR DESCRIPTION
This reverts the upgrade of the sttp client in commit 073947c7014f8c5f0e00992d7e9635292fa4c0ee.

The ugrade prevented the application to startup. It failed with an error:

```
java.lang.Error: Defect in zio.ZEnvironment: HashSet(SttpBackend[=λ %0 → ZIO[-Any,+Throwable,+0],+{package::WebSockets & ZioStreams}]) statically known to be contained within the environment are missing
```

I have created a bug report https://github.com/softwaremill/sttp/issues/2317
