### PR TITLE
docs: replace SERVICE_LOG_LEVEL by SERVICE_LOG_FORMAT

### DIFF
--- a/docs/service-configuration.md
+++ b/docs/service-configuration.md
@@ -15,7 +15,7 @@ There are a couple of groups of variables:
 |---------------------|-----------|-------------------------------------------------------------------------------|
 | `SERVICE_PORT`      | `3340`    | Port on which the service will listen                                         |
 | `SERVICE_HOST`      | `0.0.0.0` | Host on which the service will listen                                         |
-| `SERVICE_LOG_LEVEL` | `test`    | Log output format: `json` for json logging, `text` for human readable logging |
+| `SERVICE_LOG_FORMAT`| `text`    | Log output format: `json` for json logging, `text` for human readable logging |
 
 ## Storage
 


### PR DESCRIPTION
SERVICE_LOG_LEVEL exists only in the docs, but not in the code. The thing that was meant is SERVICE_LOG_FORMAT