### PR TITLE
chore(ci): Temporary workaround for ARM builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,10 @@ jobs:
           cache: sbt
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+        # Temporary workaround for ARM builds
+        # https://github.com/docker/setup-qemu-action/issues/198
+        with:
+          image: tonistiigi/binfmt:qemu-v7.0.0-28
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to Docker Hub


### PR DESCRIPTION
ARM builds have recently stopped working due to https://github.com/docker/setup-qemu-action/issues/198

Our errors
```
[error] 44.35 Setting up libc-bin (2.35-0ubuntu3.9) ...
[error] 44.48 qemu: uncaught target signal 11 (Segmentation fault) - core dumped
[error] 44.84 Segmentation fault (core dumped)
```
match with what's described in https://github.com/docker/setup-qemu-action/issues/199

The temporary workaround seems to be pinning qemu to an older version.