### PR TITLE
feat: Forward Sipi logs (DEV-4518)

### DIFF
--- a/src/main/scala/swiss/dasch/infrastructure/CommandExecutorLive.scala
+++ b/src/main/scala/swiss/dasch/infrastructure/CommandExecutorLive.scala
@@ -9,6 +9,8 @@ import swiss.dasch.config.Configuration.SipiConfig
 import swiss.dasch.domain.StorageService
 import swiss.dasch.version.BuildInfo
 import zio.{IO, UIO, ZIO, ZLayer}
+import zio.json._
+import zio.json.ast.Json
 
 import java.io.IOException
 import scala.sys.process.{ProcessLogger, stringSeqToProcess}
@@ -50,6 +52,26 @@ trait CommandExecutor {
     execute(command).filterOrElseWith(_.exitCode == 0)(out =>
       ZIO.fail(new IOException(s"Command failed: '${command.cmd}' $out")),
     )
+
+  /**
+   * Parses Sipi's JSON logs and to prepare for reporting with ZIO's configured format.
+   *
+   * @param out All logs combined.
+   * @return list item per input line
+   */
+  def parseSipiLogs(out: String): List[String] =
+    out.linesIterator.toList.filter(_.replaceAll("\\s", "").nonEmpty).map { line =>
+      line
+        .fromJson[Json.Obj]
+        .fold(
+          _ => "INFO: " ++ line.replaceFirst("\\s+", ""),
+          o => {
+            val getStr: String => Option[String] = s => o.toMap.get(s).flatMap(_.asString)
+            getStr("level").getOrElse("INFO") ++ ": " ++ getStr("message").getOrElse(line)
+          },
+        )
+        .replaceAll("[\"\\n]", ".")
+    }
 }
 
 object CommandExecutor {
@@ -58,7 +80,6 @@ object CommandExecutor {
 }
 
 final case class CommandExecutorLive(sipiConfig: SipiConfig, storageService: StorageService) extends CommandExecutor {
-
   override def buildCommand(command: String, params: String*): UIO[Command] =
     if (sipiConfig.useLocalDev) {
       for {
@@ -96,6 +117,7 @@ final case class CommandExecutorLive(sipiConfig: SipiConfig, storageService: Sto
     for {
       _   <- ZIO.logInfo(s"Executing command: ${command.cmd}")
       out <- ZIO.attemptBlockingIO(command.cmd !< logger).map(logger.buildOutput)
+      _   <- ZIO.foreachDiscard(parseSipiLogs(out.stdout ++ out.stderr))(ZIO.logInfo(_))
       _   <- ZIO.logWarning(s"Command '${command.cmd}' has err output: '$out'").when(out.stderr.nonEmpty)
     } yield out
   }

--- a/src/main/scala/swiss/dasch/infrastructure/CommandExecutorLive.scala
+++ b/src/main/scala/swiss/dasch/infrastructure/CommandExecutorLive.scala
@@ -61,7 +61,7 @@ trait CommandExecutor {
    */
   def parseSipiLogs(out: String): List[String] =
     out.linesIterator.toList.filter(_.replaceAll("\\s", "").nonEmpty).map { line =>
-      line
+      val newLine = line
         .fromJson[Json.Obj]
         .fold(
           _ => "INFO: " ++ line.replaceFirst("\\s+", ""),
@@ -71,6 +71,7 @@ trait CommandExecutor {
           },
         )
         .replaceAll("[\"\\n]", ".")
+      "Sipi: " ++ newLine
     }
 }
 

--- a/src/test/scala/swiss/dasch/infrastructure/CommandExecutorLiveSpec.scala
+++ b/src/test/scala/swiss/dasch/infrastructure/CommandExecutorLiveSpec.scala
@@ -11,12 +11,13 @@ import swiss.dasch.test.SpecConfigurations
 import swiss.dasch.version.BuildInfo
 import zio.ZLayer
 import zio.test.{ZIOSpecDefault, assertTrue}
+import zio.ZIO
 
 object CommandExecutorLiveSpec extends ZIOSpecDefault {
+  val devLayer = ZLayer.succeed(SipiConfig(useLocalDev = true)) >>> CommandExecutorLive.layer
 
   val spec = suite("CommandExecutorLive")(
     test("buildCommand with docker when useLocalDev is true") {
-      val devLayer = ZLayer.succeed(SipiConfig(useLocalDev = true)) >>> CommandExecutorLive.layer
       for {
         cmd      <- CommandExecutor.buildCommand("customCommand", "customParams").provideSome[StorageService](devLayer)
         assetDir <- StorageService.getAssetsBaseFolder().flatMap(_.toAbsolutePath)
@@ -30,6 +31,25 @@ object CommandExecutorLiveSpec extends ZIOSpecDefault {
         cmd     <- CommandExecutor.buildCommand("customCommand", "customParams").provideSome[StorageService](prodLayer)
         expected = "customCommand customParams"
       } yield assertTrue(cmd.cmd.mkString(" ") == expected)
+    },
+    test("log processing") {
+      val logExample =
+        """
+        Something bad happened
+        {"level": "ERROR", "message": "GET /0811/G5a5GeA4Jgn-ChDqwJzOJQM.jp2/0,2048,2048,111/1024,56/0/default.jpg failed (Not Found)"}
+        """
+
+      ZIO
+        .service[CommandExecutor]
+        .map { ce =>
+          assertTrue(
+            ce.parseSipiLogs(logExample) == List(
+              "INFO: Something bad happened",
+              "ERROR: GET /0811/G5a5GeA4Jgn-ChDqwJzOJQM.jp2/0,2048,2048,111/1024,56/0/default.jpg failed (Not Found)",
+            ),
+          )
+        }
+        .provideSomeLayer(devLayer)
     },
   ).provide(
     SpecConfigurations.storageConfigLayer,

--- a/src/test/scala/swiss/dasch/infrastructure/CommandExecutorLiveSpec.scala
+++ b/src/test/scala/swiss/dasch/infrastructure/CommandExecutorLiveSpec.scala
@@ -44,8 +44,8 @@ object CommandExecutorLiveSpec extends ZIOSpecDefault {
         .map { ce =>
           assertTrue(
             ce.parseSipiLogs(logExample) == List(
-              "INFO: Something bad happened",
-              "ERROR: GET /0811/G5a5GeA4Jgn-ChDqwJzOJQM.jp2/0,2048,2048,111/1024,56/0/default.jpg failed (Not Found)",
+              "Sipi: INFO: Something bad happened",
+              "Sipi: ERROR: GET /0811/G5a5GeA4Jgn-ChDqwJzOJQM.jp2/0,2048,2048,111/1024,56/0/default.jpg failed (Not Found)",
             ),
           )
         }


### PR DESCRIPTION
Since this is the main entrypoint for images entering into our repository, errors might prove beneficial for cases when formatting fails, especially now that error reporting has been improved by replacing syslog calls with just prints.