### PR TITLE
chore: Update Sipi to 31.12.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ addCommandAlias("headerCheckAll", "; all root/headerCheck Test/headerCheck; inte
 
 val flywayVersion               = "11.3.4"
 val hikariVersion               = "6.2.1"
-val knoraSipiVersion            = "v31.9.1"
+val knoraSipiVersion            = "v31.12.0"
 val quillVersion                = "4.8.6"
 val sqliteVersion               = "3.49.1.0"
 val tapirVersion                = "1.11.19"


### PR DESCRIPTION
Use docker base image from https://github.com/dasch-swiss/dsp-api/releases/tag/v31.12.0