### PR TITLE
feat: Add support for HTML and epub file types (DEV-5080)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -15,13 +15,15 @@ Assets are identified by a unique identifier, the `internal_filename`, eg. `100W
 
 ## Types of Assets
 
-The service supports different types of assets:
+The service supports several different types of assets:
 
 * Images
 * Videos
 * Audio files
 * Excel files
 * PDF files
+* Ebooks (epub)
+* Html files
 * And others in binary format
 
 The supported file formats are explained in detail in the [DSP-API documentation](https://docs.dasch.swiss/2023.06.02/DSP-API/01-introduction/file-formats/).

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,8 +22,8 @@ The service supports several different types of assets:
 * Audio files
 * Excel files
 * PDF files
-* Ebooks (epub)
-* Html files
+* Ebooks (`.epub`)
+* Html files (`.html`, `.htm`)
 * And others in binary format
 
 The supported file formats are explained in detail in the [DSP-API documentation](https://docs.dasch.swiss/2023.06.02/DSP-API/01-introduction/file-formats/).

--- a/src/main/scala/swiss/dasch/domain/SupportedFileType.scala
+++ b/src/main/scala/swiss/dasch/domain/SupportedFileType.scala
@@ -47,6 +47,7 @@ private val text =
     "txt"  -> MimeType.unsafeFrom("text/plain"),
     "json" -> MimeType.unsafeFrom("application/json"),
     "html" -> MimeType.unsafeFrom("test/html"),
+    "htm"  -> MimeType.unsafeFrom("test/html"),
     // xml, xsd, xsl are XML files, schema and stylesheets
     "xml" -> MimeType.unsafeFrom("application/xml"),
     "xsd" -> MimeType.unsafeFrom("application/xsd+xml"),

--- a/src/main/scala/swiss/dasch/domain/SupportedFileType.scala
+++ b/src/main/scala/swiss/dasch/domain/SupportedFileType.scala
@@ -26,9 +26,9 @@ private val audio =
     "wav"  -> MimeType.unsafeFrom("audio/wav"),
   )
 private val office = Seq(
-  "epub" -> MimeType.unsafeFrom("application/epub+zip"),
   "doc"  -> MimeType.unsafeFrom("application/msword"),
   "docx" -> MimeType.unsafeFrom("application/vnd.openxmlformats-officedocument.wordprocessingml.document"),
+  "epub" -> MimeType.unsafeFrom("application/epub+zip"),
   "pdf"  -> MimeType.unsafeFrom("application/pdf"),
   "ppt"  -> MimeType.unsafeFrom("application/vnd.ms-powerpoint"),
   "pptx" -> MimeType.unsafeFrom("application/vnd.openxmlformats-officedocument.presentationml.presentation"),
@@ -42,12 +42,12 @@ private val text =
   Map(
     // odd and rng are TEI formats, see
     // https://tei-c.org/guidelines/customization/getting-started-with-p5-odds/#section-2
+    "htm"  -> MimeType.unsafeFrom("text/html"),
+    "html" -> MimeType.unsafeFrom("text/html"),
+    "json" -> MimeType.unsafeFrom("application/json"),
     "odd"  -> MimeType.unsafeFrom("application/odd+xml"),
     "rng"  -> MimeType.unsafeFrom("application/rng+xml"),
     "txt"  -> MimeType.unsafeFrom("text/plain"),
-    "json" -> MimeType.unsafeFrom("application/json"),
-    "html" -> MimeType.unsafeFrom("text/html"),
-    "htm"  -> MimeType.unsafeFrom("text/html"),
     // xml, xsd, xsl are XML files, schema and stylesheets
     "xml" -> MimeType.unsafeFrom("application/xml"),
     "xsd" -> MimeType.unsafeFrom("application/xsd+xml"),
@@ -59,13 +59,13 @@ private val other = archive ++ office ++ tables ++ text
 private val movingImages = Map("mp4" -> MimeType.unsafeFrom("video/mp4"))
 
 private val stillImages = Map(
-  "jpx"  -> MimeType.unsafeFrom("image/jpx"),
   "jp2"  -> MimeType.unsafeFrom("image/jp2"),
-  "jpg"  -> MimeType.unsafeFrom("image/jpeg"),
   "jpeg" -> MimeType.unsafeFrom("image/jpeg"),
-  "tiff" -> MimeType.unsafeFrom("image/tiff"),
-  "tif"  -> MimeType.unsafeFrom("image/tiff"),
+  "jpg"  -> MimeType.unsafeFrom("image/jpeg"),
+  "jpx"  -> MimeType.unsafeFrom("image/jpx"),
   "png"  -> MimeType.unsafeFrom("image/png"),
+  "tif"  -> MimeType.unsafeFrom("image/tiff"),
+  "tiff" -> MimeType.unsafeFrom("image/tiff"),
 )
 
 /**
@@ -75,9 +75,9 @@ private val stillImages = Map(
  * @param extensions the file extensions of the supported file types.
  */
 enum SupportedFileType(val mappings: Map[String, MimeType]) derives JsonCodec {
-  case StillImage  extends SupportedFileType(stillImages)
-  case MovingImage extends SupportedFileType(movingImages)
   case Audio       extends SupportedFileType(audio)
+  case MovingImage extends SupportedFileType(movingImages)
+  case StillImage  extends SupportedFileType(stillImages)
   case OtherFiles  extends SupportedFileType(other)
 
   val extensions: Seq[String]                      = mappings.keys.toSeq

--- a/src/main/scala/swiss/dasch/domain/SupportedFileType.scala
+++ b/src/main/scala/swiss/dasch/domain/SupportedFileType.scala
@@ -46,8 +46,8 @@ private val text =
     "rng"  -> MimeType.unsafeFrom("application/rng+xml"),
     "txt"  -> MimeType.unsafeFrom("text/plain"),
     "json" -> MimeType.unsafeFrom("application/json"),
-    "html" -> MimeType.unsafeFrom("test/html"),
-    "htm"  -> MimeType.unsafeFrom("test/html"),
+    "html" -> MimeType.unsafeFrom("text/html"),
+    "htm"  -> MimeType.unsafeFrom("text/html"),
     // xml, xsd, xsl are XML files, schema and stylesheets
     "xml" -> MimeType.unsafeFrom("application/xml"),
     "xsd" -> MimeType.unsafeFrom("application/xsd+xml"),

--- a/src/main/scala/swiss/dasch/domain/SupportedFileType.scala
+++ b/src/main/scala/swiss/dasch/domain/SupportedFileType.scala
@@ -26,6 +26,7 @@ private val audio =
     "wav"  -> MimeType.unsafeFrom("audio/wav"),
   )
 private val office = Seq(
+  "epub" -> MimeType.unsafeFrom("application/epub+zip"),
   "doc"  -> MimeType.unsafeFrom("application/msword"),
   "docx" -> MimeType.unsafeFrom("application/vnd.openxmlformats-officedocument.wordprocessingml.document"),
   "pdf"  -> MimeType.unsafeFrom("application/pdf"),
@@ -45,6 +46,7 @@ private val text =
     "rng"  -> MimeType.unsafeFrom("application/rng+xml"),
     "txt"  -> MimeType.unsafeFrom("text/plain"),
     "json" -> MimeType.unsafeFrom("application/json"),
+    "html" -> MimeType.unsafeFrom("test/html"),
     // xml, xsd, xsl are XML files, schema and stylesheets
     "xml" -> MimeType.unsafeFrom("application/xml"),
     "xsd" -> MimeType.unsafeFrom("application/xsd+xml"),

--- a/src/test/scala/swiss/dasch/domain/SupportedFileTypeSpec.scala
+++ b/src/test/scala/swiss/dasch/domain/SupportedFileTypeSpec.scala
@@ -15,9 +15,9 @@ object SupportedFileTypeSpec extends ZIOSpecDefault {
     test("All valid extensions for Other are supported") {
 
       val archive = Seq("7z", "gz", "gzip", "tar", "tar.gz", "tgz", "z", "zip")
-      val office  = Seq("doc", "docx", "pdf", "ppt", "pptx")
+      val office  = Seq("doc", "docx", "pdf", "ppt", "pptx", "epub")
       val tables  = Seq("csv", "xls", "xlsx")
-      val text    = Seq("odd", "rng", "txt", "json", "xml", "xsd", "xsl")
+      val text    = Seq("odd", "rng", "txt", "html", "htm", "json", "xml", "xsd", "xsl")
 
       val otherFileTypeExtensions = text ++ tables ++ office ++ archive
       check(Gen.fromIterable(withUpperCase(otherFileTypeExtensions))) { ext =>
@@ -48,7 +48,7 @@ object SupportedFileTypeSpec extends ZIOSpecDefault {
       }
     },
     test("Unknown file extensions are not supported") {
-      val sampleUnknown = Seq("epub", "iff", "m3u", "mob", "odf", "xslt")
+      val sampleUnknown = Seq("iff", "m3u", "mob", "odf", "xslt")
       check(Gen.fromIterable(withUpperCase(sampleUnknown))) { ext =>
         assertTrue(SupportedFileType.fromPath(Path(s"test.$ext")).isEmpty)
       }


### PR DESCRIPTION
- **add mimetypes: https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/MIME_types/Common_types**
- **feat: Add support for HTML and epub file types**

Updated the api documentation in https://github.com/dasch-swiss/dsp-api/pull/3649
