### PR TITLE
chore: Mark repo as archived and code included into the DSP-API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-# Archived and moved into [DSP-API](https://github.com/dasch-swiss/dsp-api/)
+> [!CAUTION]
+> **THIS REPO HAS BEEN ARCHIVED.**
 
-<hr><hr><hr>
+<hr>
 
 #### Dsp-Ingest
 


### PR DESCRIPTION
<img width="901" height="910" alt="Screenshot 2025-09-08 at 17 06 04" src="https://github.com/user-attachments/assets/1a2405da-44de-4644-8147-34eaf23af7e7" />
